### PR TITLE
Add Support for TGW Routes & Default IPAM Scope

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          aws-region: us-west-2
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Run Tests
@@ -80,6 +81,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          aws-region: us-west-2
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Run Tests

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -48,6 +48,7 @@ jobs:
   integration:
     name: Test live integration terraform-aws-networking
     runs-on: ubuntu-latest
+    environment: PR_WORKFLOW
     timeout-minutes: 20
     needs:
       - mock
@@ -62,6 +63,7 @@ jobs:
   cleanup:
     name: Cleanup live integration terraform-aws-networking
     runs-on: ubuntu-latest
+    environment: PR_WORKFLOW
     timeout-minutes: 20
     needs:
       - integration

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs:
-      - test
+      - mock
     if: needs.test.outputs.run_live == 'yes'
     steps:
       - name: Checkout code
@@ -51,3 +51,16 @@ jobs:
         run: ./bin/install_deb.sh
       - name: Run Tests
         run: ./bin/run_live_tests.sh
+  cleanup:
+    name: Cleanup live integration terraform-aws-networking
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - integration
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Tarraform
+        run: ./bin/install_aws_nuke.sh
+      - name: Run Tests
+        run: ./bin/run_nuke.sh

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,10 +21,18 @@ jobs:
       - name: Check Formatting
         id: formattingCheck
         run: ./bin/check_formatting.sh
+      - id: set
+        run: |
+          echo "::set-output name=run_mock::yes"
+    outputs:
+      run_live: ${{ steps.set.outputs.run_mock }}
   mock:
     name: Test mock terraform-aws-networking
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs:
+      - format
+    if: needs.format.outputs.run_mock == 'yes'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -43,7 +51,7 @@ jobs:
     timeout-minutes: 20
     needs:
       - mock
-    if: needs.test.outputs.run_live == 'yes'
+    if: needs.mock.outputs.run_live == 'yes'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup Tarraform
+      - name: Setup AWS Nuke
         run: ./bin/install_aws_nuke.sh
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Check Formatting
         id: formattingCheck
         run: ./bin/check_formatting.sh
-  test:
-    name: Test terraform-aws-networking
+  mock:
+    name: Test mock terraform-aws-networking
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -32,3 +32,22 @@ jobs:
         run: ./bin/install_deb.sh
       - name: Run Tests
         run: ./bin/run_tests.sh
+      - id: set
+        run: |
+          echo "::set-output name=run_live::yes"
+    outputs:
+      run_live: ${{ steps.set.outputs.run_live }}
+  integration:
+    name: Test live integration terraform-aws-networking
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - test
+    if: needs.test.outputs.run_live == 'yes'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Tarraform
+        run: ./bin/install_deb.sh
+      - name: Run Tests
+        run: ./bin/run_live_tests.sh

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "::set-output name=run_mock::yes"
     outputs:
-      run_live: ${{ steps.set.outputs.run_mock }}
+      run_mock: ${{ steps.set.outputs.run_mock }}
   mock:
     name: Test mock terraform-aws-networking
     runs-on: ubuntu-latest

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -84,5 +84,5 @@ jobs:
           aws-region: us-west-2
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Run Tests
+      - name: Run AWS Nuke
         run: ./bin/run_nuke.sh

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -58,6 +58,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Tarraform
         run: ./bin/install_deb.sh
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Run Tests
         run: ./bin/run_live_tests.sh
   cleanup:
@@ -72,5 +77,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Tarraform
         run: ./bin/install_aws_nuke.sh
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Run Tests
         run: ./bin/run_nuke.sh

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ variables {
     transit_gw = {
       tgw_is_enabled = true
       tgw_vpc_attach = ["infra1", "egress"]
+      tgw_routes = [
+        {
+          "destination" = "0.0.0.0/0"
+          "vpc_attachment"  = "egress"
+        }
+      ]
     }
   }
 }
@@ -298,7 +304,9 @@ The following example will create:
 | vpcs.tgw_config.route_destinations | This will configure routes within the VPC Route Tables to the Transit Gateway. The configured value can be static, such as "0.0.0.0/0", or dynamic, similar to the NACL rules.  When using dynamic, utilize the VPC name you assigned to the VPC under "vpcs".  aws-networking module will replace the VPC name with the assigned CIDR. | `list(string)`
 | transit_gw.tgw_is_enabled | Boolean value to indicate that aws-networking should create a Transit Gateway. | `bool`
 | transit_gw.tgw_vpc_attach | List of named VPCs to attach to the Transit Gateway. | `list(string)`
-
+| transit_gw.tgw_routes | List of routes to add into the Transit Gateway. | `list(object())`
+| transit_gw.tgw_routes.*.destination | Destination route, such as `0.0.0.0/0` or a VPC name like `egress`. | `string`
+| transit_gw.tgw_routes.*.vpc_attachment | Name of the VPC that is attached to Transit Gateway in `transit_gw.tgw_vpc_attach`. This will point the destination toward the VPC named in this parameter. | `string`
 
 ## Major Revision Updates
 
@@ -461,6 +469,7 @@ The following example will create:
 				"ec2:ResetNetworkInterfaceAttribute",
 				"ec2:RevokeSecurityGroupEgress",
 				"ec2:RevokeSecurityGroupEgress",
+        "ec2:SearchTransitGatewayRoutes",
 				"ec2:UnassignIpv6Addresses",
 				"ec2:UnassignPrivateIpAddresses"
 			],

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ The following example will create:
 				"ec2:DeleteVpc",
 				"ec2:DeleteVpcEndpoints",
 				"ec2:DeleteVpcEndpointServiceConfigurations",
+        "ec2:DeleteDhcpOptions",
 				"ec2:DescribeAccountAttributes",
 				"ec2:DescribeAddresses",
 				"ec2:DescribeAvailabilityZones",

--- a/bin/check_formatting.sh
+++ b/bin/check_formatting.sh
@@ -5,7 +5,7 @@ printf "###########################################\n"
 printf "## CHECKING FOR MISSED FORMATTING #########\n"
 printf "###########################################\n\n"
 
-if [[ $(terraform fmt -recursive) ]]; then
+if [[ $(terraform fmt -recursive -check) ]]; then
   printf "## Please format before pushing with 'terraform fmt -recursive' in the root directory\n\n"
   exit 1
 else

--- a/bin/install_aws_nuke.sh
+++ b/bin/install_aws_nuke.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Terraform AWS Nuke
-wget -c https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz -O - | tar -xz -C $HOME/.local/bin
-mv $HOME/.local/bin/aws-nuke-v2.25.0-linux-amd64 $HOME/.local/bin/aws-nuke
+wget -c https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz -O - | tar -xz -C $PWD
+mv $PWD/aws-nuke-v2.25.0-linux-amd64 $PWD/aws-nuke

--- a/bin/install_aws_nuke.sh
+++ b/bin/install_aws_nuke.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Terraform AWS Nuke
+wget -c https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz -O - | tar -xz -C $HOME/.local/bin
+mv $HOME/.local/bin/aws-nuke-v2.25.0-linux-amd64 $HOME/.local/bin/aws-nuke

--- a/bin/run_live_tests.sh
+++ b/bin/run_live_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script will run live integration tests
+printf "## Initializing integration test\n\n"
+terraform init
+printf "## Validating terraform-aws-networking module\n\n"
+terraform validate
+printf "## Running live integration tests\n\n"
+terraform test -filter=tests/integration_live.tftest.hcl

--- a/bin/run_nuke.sh
+++ b/bin/run_nuke.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # This script will run live integration tests
-$HOME/.local/bin/aws-nuke -c ./config/nuke_config.yml --force --no-dry-run
+$PWD/aws-nuke -c ./config/nuke_config.yml --force --no-dry-run

--- a/bin/run_nuke.sh
+++ b/bin/run_nuke.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This script will run live integration tests
+$HOME/.local/bin/aws-nuke -c ./config/nuke_config.yml --force --no-dry-run

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -38,4 +38,4 @@ terraform init
 printf "## Validating terraform-aws-networking module\n\n"
 terraform validate
 printf "## Running integration tests\n\n"
-terraform test
+terraform test -filter=tests/integration.tftest.hcl

--- a/config/nuke_config.yml
+++ b/config/nuke_config.yml
@@ -1,0 +1,38 @@
+regions:
+- us-west-2
+
+account-blocklist:
+- 123456789012
+
+resource-types:
+  targets:
+  - EC2Address
+  - EC2ClientVpnEndpoint
+  - EC2ClientVpnEndpointAttachment
+  - EC2CustomerGateway
+  - EC2DHCPOption
+  - EC2DefaultSecurityGroupRule
+  - EC2EgressOnlyInternetGateway
+  - EC2InternetGateway
+  - EC2InternetGatewayAttachment
+  - EC2NATGateway
+  - EC2NetworkACL
+  - EC2NetworkInterface
+  - EC2RouteTable
+  - EC2SecurityGroup
+  - EC2Subnet
+  - EC2TGW
+  - EC2TGWAttachment
+  - EC2VPC
+  - EC2VPCEndpoint
+  - EC2VPCEndpointConnection
+  - EC2VPCEndpointServiceConfiguration
+  - EC2VPCPeeringConnection
+  - EC2VPNConnection
+  - EC2VPNGateway
+  - EC2VPNGatewayAttachment
+  excludes:
+  - IAM*
+
+accounts:
+  533267038789: {}

--- a/main.tf
+++ b/main.tf
@@ -134,8 +134,8 @@ module "aws-vpc-tgw" {
   ])
   tgw_routes = flatten([
     for route in var.network_config.transit_gw.tgw_routes : {
-      destination       = can(module.aws-vpc[route.destination].vpc_cidr_block) ? module.aws-vpc[route.destination].vpc_cidr_block : route.destination
-      vpc_attachment   = route.vpc_attachment
+      destination    = can(module.aws-vpc[route.destination].vpc_cidr_block) ? module.aws-vpc[route.destination].vpc_cidr_block : route.destination
+      vpc_attachment = route.vpc_attachment
     }
   ])
   tgw_vpc_attach = var.network_config.transit_gw.tgw_vpc_attach

--- a/main.tf
+++ b/main.tf
@@ -132,5 +132,11 @@ module "aws-vpc-tgw" {
       ]
     ]
   ])
+  tgw_routes = flatten([
+    for route in var.network_config.transit_gw.tgw_routes : {
+      destination       = can(module.aws-vpc[route.destination].vpc_cidr_block) ? module.aws-vpc[route.destination].vpc_cidr_block : route.destination
+      vpc_attachment   = route.vpc_attachment
+    }
+  ])
   tgw_vpc_attach = var.network_config.transit_gw.tgw_vpc_attach
 }

--- a/modules/aws-acct-ipam/main.tf
+++ b/modules/aws-acct-ipam/main.tf
@@ -24,7 +24,7 @@ data "aws_vpc_ipam_pools" "region_ipam_pools" {
 
 #Create IPAM Scope for Account
 resource "aws_vpc_ipam" "region_ipam" {
-  count = length(data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools) == 0 ? 1 : 0
+  count       = length(data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools) == 0 ? 1 : 0
   description = "${var.project_name}-${var.environment}-account-ipan"
   operating_regions {
     region_name = data.aws_region.current.name
@@ -37,7 +37,7 @@ resource "aws_vpc_ipam" "region_ipam" {
 
 #If no IPAM pools exist, then use the created scope, otherwise use the first pool
 locals {
-  depends_on = [ data.aws_vpc_ipam_pools.region_ipam_pools, aws_vpc_ipam.region_ipam ]
+  depends_on               = [data.aws_vpc_ipam_pools.region_ipam_pools, aws_vpc_ipam.region_ipam]
   private_default_scope_id = length(data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools) == 0 ? aws_vpc_ipam.region_ipam[*].private_default_scope_id : data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools[*].ipam_scope_id
 }
 

--- a/modules/aws-acct-ipam/main.tf
+++ b/modules/aws-acct-ipam/main.tf
@@ -15,9 +15,16 @@ terraform {
 }
 
 data "aws_region" "current" {}
+data "aws_vpc_ipam_pools" "region_ipam_pools" {
+  filter {
+    name   = "address-family"
+    values = ["ipv4"]
+  }
+}
 
 #Create IPAM Scope for Account
-resource "aws_vpc_ipam" "account_ipam" {
+resource "aws_vpc_ipam" "region_ipam" {
+  count = length(data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools) == 0 ? 1 : 0
   description = "${var.project_name}-${var.environment}-account-ipan"
   operating_regions {
     region_name = data.aws_region.current.name
@@ -28,14 +35,22 @@ resource "aws_vpc_ipam" "account_ipam" {
   }
 }
 
-resource "aws_vpc_ipam_pool" "acct_ipam_pool" {
+#If no IPAM pools exist, then use the created scope, otherwise use the first pool
+locals {
+  depends_on = [ data.aws_vpc_ipam_pools.region_ipam_pools, aws_vpc_ipam.region_ipam ]
+  private_default_scope_id = length(data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools) == 0 ? aws_vpc_ipam.region_ipam[*].private_default_scope_id : data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools[*].ipam_scope_id
+}
+
+
+
+resource "aws_vpc_ipam_pool" "region_ipam_pool" {
   description                       = "${var.project_name}-${var.environment}-vpc-ipam-pool"
   address_family                    = "ipv4"
   allocation_default_netmask_length = 16
-  ipam_scope_id                     = aws_vpc_ipam.account_ipam.private_default_scope_id
+  ipam_scope_id                     = local.private_default_scope_id[0]
 }
 
 resource "aws_vpc_ipam_pool_cidr" "acct_ipam_pool_cidr" {
-  ipam_pool_id = aws_vpc_ipam_pool.acct_ipam_pool.id
+  ipam_pool_id = aws_vpc_ipam_pool.region_ipam_pool.id
   cidr         = var.parent_pool_cidr_block
 }

--- a/modules/aws-acct-ipam/main.tf
+++ b/modules/aws-acct-ipam/main.tf
@@ -41,8 +41,7 @@ locals {
   private_default_scope_id = length(data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools) == 0 ? aws_vpc_ipam.region_ipam[*].private_default_scope_id : data.aws_vpc_ipam_pools.region_ipam_pools.ipam_pools[*].ipam_scope_id
 }
 
-
-
+#TODO Check for pool overlap for the main parent pool if scope already exists and add tests
 resource "aws_vpc_ipam_pool" "region_ipam_pool" {
   description                       = "${var.project_name}-${var.environment}-vpc-ipam-pool"
   address_family                    = "ipv4"

--- a/modules/aws-acct-ipam/outputs.tf
+++ b/modules/aws-acct-ipam/outputs.tf
@@ -1,9 +1,9 @@
 output "acct_ipam_scope_id" {
   description = "Account IPAM Scope ID"
-  value       = aws_vpc_ipam.account_ipam.private_default_scope_id
+  value       = local.private_default_scope_id[0]
 }
 
 output "acct_ipam_pool_id" {
   description = "Account IPAM Pool ID"
-  value       = aws_vpc_ipam_pool.acct_ipam_pool.id
+  value       = aws_vpc_ipam_pool.region_ipam_pool.id
 }

--- a/modules/aws-vpc-tgw/main.tf
+++ b/modules/aws-vpc-tgw/main.tf
@@ -56,3 +56,17 @@ resource "aws_route" "tgw_route" {
   transit_gateway_id     = aws_ec2_transit_gateway.transit_gateway.id
   depends_on             = [aws_ec2_transit_gateway_vpc_attachment.transit_gateway]
 }
+
+# Update Transit Gateway Routes
+resource "aws_ec2_transit_gateway_route" "tgw_route_table_routes" {
+  count                = length(var.tgw_routes)
+  destination_cidr_block = var.tgw_routes[count.index].destination
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.transit_gateway[var.tgw_routes[count.index].vpc_attachment].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway.transit_gateway.association_default_route_table_id
+  lifecycle {
+    precondition {
+      condition = can(cidrsubnet(var.tgw_routes[count.index].destination, 0, 0))
+      error_message = "Invalid CIDR block in transit_gw.tgw_routes for Transit Gateway Route."
+    }
+  }
+}

--- a/modules/aws-vpc-tgw/main.tf
+++ b/modules/aws-vpc-tgw/main.tf
@@ -59,13 +59,13 @@ resource "aws_route" "tgw_route" {
 
 # Update Transit Gateway Routes
 resource "aws_ec2_transit_gateway_route" "tgw_route_table_routes" {
-  count                = length(var.tgw_routes)
-  destination_cidr_block = var.tgw_routes[count.index].destination
-  transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.transit_gateway[var.tgw_routes[count.index].vpc_attachment].id
+  count                          = length(var.tgw_routes)
+  destination_cidr_block         = var.tgw_routes[count.index].destination
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.transit_gateway[var.tgw_routes[count.index].vpc_attachment].id
   transit_gateway_route_table_id = aws_ec2_transit_gateway.transit_gateway.association_default_route_table_id
   lifecycle {
     precondition {
-      condition = can(cidrsubnet(var.tgw_routes[count.index].destination, 0, 0))
+      condition     = can(cidrsubnet(var.tgw_routes[count.index].destination, 0, 0))
       error_message = "Invalid CIDR block in transit_gw.tgw_routes for Transit Gateway Route."
     }
   }

--- a/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
+++ b/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
@@ -27,6 +27,12 @@ variables {
     }
   ]
   tgw_vpc_attach = ["infra1", "egress"]
+  tgw_routes = [
+    {
+      "destination" = "0.0.0.0/0"
+      "vpc_attachment"  = "egress"
+    }
+  ]
 }
 
 run "positive_standard_config" {
@@ -46,6 +52,60 @@ run "positive_standard_config_route_table_routes" {
     condition     = length(aws_route.tgw_route) == 2
     error_message = "Expected 2 Route Table Updates"
   }
+
+}
+
+run "positive_tgw_routes" {
+  command = plan
+
+  assert {
+    condition     = length(aws_ec2_transit_gateway_route.tgw_route_table_routes) == 1
+    error_message = "Expected 1 Additional TGW Route"
+  }
+
+}
+
+run "positive_named_tgw_routes" {
+  command = plan
+
+  variables {
+    tgw_routes = [
+      {
+        "destination" = "infra1"
+        "vpc_attachment"  = "egress"
+      },
+      {
+        "destination" = "0.0.0.0/0"
+        "vpc_attachment"  = "egress"
+      }
+    ]
+  }
+
+  expect_failures = [
+    aws_ec2_transit_gateway_route.tgw_route_table_routes
+  ]
+
+}
+
+run "nagative_invalid_route_tgw_routes" {
+  command = plan
+
+  variables {
+    tgw_routes = [
+      {
+        "destination" = "10.0.0.0/-1"
+        "vpc_attachment"  = "egress"
+      },
+      {
+        "destination" = "0.0.0.0/0"
+        "vpc_attachment"  = "egress"
+      }
+    ]
+  }
+
+  expect_failures = [
+    aws_ec2_transit_gateway_route.tgw_route_table_routes
+  ]
 
 }
 

--- a/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
+++ b/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
@@ -29,8 +29,8 @@ variables {
   tgw_vpc_attach = ["infra1", "egress"]
   tgw_routes = [
     {
-      "destination" = "0.0.0.0/0"
-      "vpc_attachment"  = "egress"
+      "destination"    = "0.0.0.0/0"
+      "vpc_attachment" = "egress"
     }
   ]
 }
@@ -71,12 +71,12 @@ run "positive_named_tgw_routes" {
   variables {
     tgw_routes = [
       {
-        "destination" = "infra1"
-        "vpc_attachment"  = "egress"
+        "destination"    = "infra1"
+        "vpc_attachment" = "egress"
       },
       {
-        "destination" = "0.0.0.0/0"
-        "vpc_attachment"  = "egress"
+        "destination"    = "0.0.0.0/0"
+        "vpc_attachment" = "egress"
       }
     ]
   }
@@ -93,12 +93,12 @@ run "nagative_invalid_route_tgw_routes" {
   variables {
     tgw_routes = [
       {
-        "destination" = "10.0.0.0/-1"
-        "vpc_attachment"  = "egress"
+        "destination"    = "10.0.0.0/-1"
+        "vpc_attachment" = "egress"
       },
       {
-        "destination" = "0.0.0.0/0"
-        "vpc_attachment"  = "egress"
+        "destination"    = "0.0.0.0/0"
+        "vpc_attachment" = "egress"
       }
     ]
   }

--- a/modules/aws-vpc-tgw/variables.tf
+++ b/modules/aws-vpc-tgw/variables.tf
@@ -29,6 +29,19 @@ variable "tgw_vpc_attach" {
   type        = list(string)
 }
 
+variable "tgw_routes" {
+  description = "Added Transit Gateway Routes"
+  type        = list(
+    object(
+      {
+        destination  = string,
+        vpc_attachment  = string
+      }
+    )
+  )
+  default = []
+}
+
 variable "project_name" {
   description = "Project Name"
   type        = string

--- a/modules/aws-vpc-tgw/variables.tf
+++ b/modules/aws-vpc-tgw/variables.tf
@@ -31,11 +31,11 @@ variable "tgw_vpc_attach" {
 
 variable "tgw_routes" {
   description = "Added Transit Gateway Routes"
-  type        = list(
+  type = list(
     object(
       {
-        destination  = string,
-        vpc_attachment  = string
+        destination    = string,
+        vpc_attachment = string
       }
     )
   )

--- a/tests/integration.tftest.hcl
+++ b/tests/integration.tftest.hcl
@@ -188,8 +188,8 @@ variables {
       tgw_vpc_attach = ["infra1", "egress"]
       tgw_routes = [
         {
-          "destination" = "0.0.0.0/0"
-          "vpc_attachment"  = "egress"
+          "destination"    = "0.0.0.0/0"
+          "vpc_attachment" = "egress"
         }
       ]
     }

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -179,8 +179,8 @@ variables {
       tgw_vpc_attach = ["infra1", "egress"]
       tgw_routes = [
         {
-          "destination" = "0.0.0.0/0"
-          "vpc_attachment"  = "egress"
+          "destination"    = "0.0.0.0/0"
+          "vpc_attachment" = "egress"
         }
       ]
     }

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -1,14 +1,5 @@
-mock_provider "aws" {
-  mock_data "aws_availability_zones" {
-    defaults = {
-      names = ["1a", "1b", "1c", "1d"]
-    }
-  }
-  mock_data "aws_region" {
-    defaults = {
-      name = "us-east-1"
-    }
-  }
+provider "aws" {
+  region = "us-west-2"
 }
 
 variables {
@@ -196,8 +187,19 @@ variables {
   }
 }
 
-run "positive_integration_test_with_known_good_configuration" {
+run "positive_integration_test_with_known_good_configuration_plan" {
   command = plan
+
+  assert {
+    condition     = length(module.aws-vpc) == 2
+    error_message = "Expected 2 VPCs Created"
+  }
+
+}
+
+#TODO Add more validations
+run "positive_integration_test_with_known_good_configuration_apply" {
+  command = apply
 
   assert {
     condition     = length(module.aws-vpc) == 2

--- a/variables.tf
+++ b/variables.tf
@@ -68,9 +68,9 @@ variable "network_config" {
       transit_gw = object({
         tgw_is_enabled = bool
         tgw_vpc_attach = list(string)
-        tgw_routes     = list(object({
-          destination       = string
-          vpc_attachment   = string
+        tgw_routes = list(object({
+          destination    = string
+          vpc_attachment = string
         }))
       })
   })

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,10 @@ variable "network_config" {
       transit_gw = object({
         tgw_is_enabled = bool
         tgw_vpc_attach = list(string)
+        tgw_routes     = list(object({
+          destination       = string
+          vpc_attachment   = string
+        }))
       })
   })
 }


### PR DESCRIPTION
Allow configuration of addtional routes to be placed into
the Transit Gateway, such as 0.0.0.0/0 out a specific attached
VPC.  Additionally, check if IPAM scope already exists and use
the scope id for all subsequent allocations.  Additional checks
need to be added for the parent pool to check if there is already
a pool but this is a corner case that can wait.

For testing, add support for live integration testing with aws-nuke
support to cleanup any failures.

Closes #2, Closes #10