### PR TITLE
Add Support for Additional Private Subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Terraform Module to simplify the creation of complex AWS VPC Networking configur
 
 ## Usage Example
 ```
-variables {
+locals {
   project_name           = "projecta"
   environment            = "test"
   parent_pool_cidr_block = "10.0.0.0/8"
@@ -235,13 +235,17 @@ variables {
   }
 }
 
+provider "aws" {
+  region = "us-west-2"
+}
+
 module "aws-networking" {
   source  = "stajkowski/networking/aws"
   version = "2.0.0"
   project_name = local.project_name
   environment = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
-  network_config = local.env_network_config[var.environment]
+  network_config = local.network_config
 }
 ```
 The following example will create:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 16
         subnet_mask          = 24
+        additional_private_subnets   = {}
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -104,6 +105,40 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 16
         subnet_mask          = 24
+        additional_private_subnets   = {
+          "db" = {
+            subnet_count = 2
+            nacl_rules = [
+              {
+                rule_number = 10
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "infra1"
+                from_port   = 3306
+                to_port     = 3306
+              },
+              {
+                rule_number = 20
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "ipam_account_pool"
+                from_port   = 1024
+                to_port     = 65535
+              },
+              {
+                rule_number = 10
+                egress      = true
+                action      = "allow"
+                protocol    = -1
+                cidr_block  = "ipam_account_pool"
+                from_port   = 0
+                to_port     = 0
+              }
+            ]
+          }
+        }
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -202,7 +237,7 @@ variables {
 
 module "aws-networking" {
   source  = "stajkowski/networking/aws"
-  version = "1.0.0"
+  version = "2.0.0"
   project_name = local.project_name
   environment = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
@@ -222,10 +257,11 @@ The following example will create:
 8. In the "egress" VPC, a VPCE Gateway is added for "s3" in the public/private route tables.
 8. In the "egress" VPC, private link support is added ("ec2 &"sts") to each private subnet since scope is "private".
 9. In the "infra1" VPC, private link support is added ("ec2 &"sts") to each private subnet since scope is "private".
-10. A single Transit Gateway with VPCs "egress" and "infra1" attached.
-11. Route destination "0.0.0.0/0" is added to the private route tables in "infra1" VPC.
-12. Route destination "infra1" (auto substituted for infra 1 CIDR) is added to public/private route tables in "egress" VPC.
-13. A default security group that can be used per VPC that allows parent IPAM pool CIDR of "10.0.0.0/8"
+10. Two additional private subnets for the "db" group in the "infra1" VPC with NACL rules associated and private route table association.
+11. A single Transit Gateway with VPCs "egress" and "infra1" attached.
+12. Route destination "0.0.0.0/0" is added to the private route tables in "infra1" VPC.
+13. Route destination "infra1" (auto substituted for infra 1 CIDR) is added to public/private route tables in "egress" VPC.
+14. A default security group that can be used per VPC that allows parent IPAM pool CIDR of "10.0.0.0/8"
 
 *NOTE*: Size of each VPC CIDR and subnet mask can be controlled through the configuration "vpc_cidr_subnet_mask" and "subnet_mask"
 
@@ -292,6 +328,9 @@ The following example will create:
 | vpcs.private_subnets | Number of private subnets to create in the VPC.  This is required to be > 0 if a priate NAT Gateway is configured for the VPC. | `number`
 | vpcs.vpc_cidr_subnet_mask | Length of mask for auto assignment of the VPC CIDR. | `number`
 | vpcs.subnet_mask | Length of mask for auto assignment of VPC Subnets. | `number`
+| vpcs.additional_private_subnets | Map of additional private subnets to create and associate with private route table with NACL rules. | `map(object{})`
+| vpcs.additional_private_subnets.`id`.subnet_count | The number of subnets to create for this additional private subnet group. | `number`
+| vpcs.additional_private_subnets.`id`.nacl_rules | This will iterate over the configured NACL rules and assign them to the private subnet group subnet ids. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR  for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR. Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
 | vpcs.gw_services.igw_is_enabled | Boolean value to indicate if an Internet Gateway is to be configured for the VPC. | `bool`
 | vpcs.gw_services.nat_gw_is_enabled | Boolean value to indicate if a NAT Gateway is to be configured for the VPC. | `bool`
 | vpcs.gw_services.nat_gw_type | (`public`, `private`) NAT Gateway type is direct confgiuration of the aws module and can be public or private.  Public NAT Gateway requires creation of an Internet Gateway to allow traffic to exit to the Internet. Private NAT Gateways: https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/private-nat-gateway.html. Public NAT Gateway Architecture: https://docs.aws.amazon.com/network-firewall/latest/developerguide/arch-igw-ngw.html | `string`
@@ -299,8 +338,8 @@ The following example will create:
 | vpcs.gw_services.vpc_gateway_services | This is a list of VPCE Gateway services to create and associate with public/private subnets.  Please refer to AWS Documentation on which services support VPCE Gateway but as of this release, only "s3" and "dynamodb" are supported. | `list(string)`
 | vpcs.gw_services.vpc_interface_services | This is a list of services to create Interface Endpoints (PrivateLink).  The difference between VPCE Gateway and Interface Endpoint (PrivateLink), is that Interface Endpoint allows access to AWS services through an IP Address assigned from within your subnets, whereas, VPCE Gateway endpoints inject routes into your associated routing tables. Please refer to AWS documentation for supported services (https://docs.aws.amazon.com/vpc/latest/privatelink/aws-services-privatelink-support.html) and please use the service name in the endpoint, i.e. for "com.amazonaws.us-east-1.s3" you would set this configuration to ["s3"] | `list(string)`
 | vpcs.gw_services.vpc_interface_services_scope | (`private`, `both`) This will control in aws-networking module which subnets to attach to the Interface Endpoint.  `private` will attach only private subnets, whereas `both` will assign both public and private subnets to the Interface Endpoint.
-| vpcs.public_subnet_nacl_rules | This will iterate over the configured NACL rules and assign them to the public route table. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR.  Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
-| vpcs.public_subnet_nacl_rules | This will iterate over the configured NACL rules and assign them to the private route table. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR  for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR. Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
+| vpcs.public_subnet_nacl_rules | This will iterate over the configured NACL rules and assign them to the public subnet ids. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR.  Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
+| vpcs.private_subnet_nacl_rules | This will iterate over the configured NACL rules and assign them to the private subnet ids. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR  for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR. Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
 | vpcs.tgw_config.route_destinations | This will configure routes within the VPC Route Tables to the Transit Gateway. The configured value can be static, such as "0.0.0.0/0", or dynamic, similar to the NACL rules.  When using dynamic, utilize the VPC name you assigned to the VPC under "vpcs".  aws-networking module will replace the VPC name with the assigned CIDR. | `list(string)`
 | transit_gw.tgw_is_enabled | Boolean value to indicate that aws-networking should create a Transit Gateway. | `bool`
 | transit_gw.tgw_vpc_attach | List of named VPCs to attach to the Transit Gateway. | `list(string)`
@@ -326,6 +365,10 @@ The following example will create:
 12. Private Interface Gateway will associate interface gateway with private subnets only.
 13. Transit Gateway with VPC assignment.
 14. Transit Gateway route updates for every route table in the assigned VPC.
+
+#### Version 2.0
+
+1. Support for additional named private subnets.
 
 ## Required Permissions
 ```
@@ -420,7 +463,7 @@ The following example will create:
 				"ec2:DeleteVpc",
 				"ec2:DeleteVpcEndpoints",
 				"ec2:DeleteVpcEndpointServiceConfigurations",
-                "ec2:DeleteDhcpOptions",
+				"ec2:DeleteDhcpOptions",
 				"ec2:DescribeAccountAttributes",
 				"ec2:DescribeAddresses",
 				"ec2:DescribeAvailabilityZones",
@@ -470,7 +513,7 @@ The following example will create:
 				"ec2:ResetNetworkInterfaceAttribute",
 				"ec2:RevokeSecurityGroupEgress",
 				"ec2:RevokeSecurityGroupEgress",
-                "ec2:SearchTransitGatewayRoutes",
+				"ec2:SearchTransitGatewayRoutes",
 				"ec2:UnassignIpv6Addresses",
 				"ec2:UnassignPrivateIpAddresses"
 			],

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,231 @@
+locals {
+  project_name           = "projecta"
+  environment            = "test"
+  parent_pool_cidr_block = "10.0.0.0/8"
+  network_config = {
+    vpcs = {
+      "egress" = {
+        public_subnets       = 2
+        private_subnets      = 2
+        vpc_cidr_subnet_mask = 16
+        subnet_mask          = 24
+        additional_private_subnets   = {}
+        public_subnet_nacl_rules = [
+          {
+            rule_number = 10
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 443
+            to_port     = 443
+          },
+          {
+            rule_number = 20
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 80
+            to_port     = 80
+          },
+          {
+            rule_number = 10
+            egress      = true
+            action      = "allow"
+            protocol    = -1
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 0
+            to_port     = 0
+          }
+        ]
+        private_subnet_nacl_rules = [
+          {
+            rule_number = 10
+            egress      = false
+            action      = "allow"
+            protocol    = -1
+            cidr_block  = "infra1"
+            from_port   = 0
+            to_port     = 0
+          },
+          {
+            rule_number = 20
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "ipam_account_pool"
+            from_port   = 22
+            to_port     = 22
+          },
+          {
+            rule_number = 10
+            egress      = true
+            action      = "allow"
+            protocol    = -1
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 0
+            to_port     = 0
+          }
+        ]
+        gw_services = {
+          igw_is_enabled       = true
+          nat_gw_is_enabled    = true
+          nat_gw_type          = "public"
+          nat_gw_ha            = true
+          vpc_gateway_services = ["s3"]
+          vpc_interface_services = [
+            "ec2", "sts"
+          ]
+          vpc_interface_services_scope = "private"
+        }
+        tgw_config = {
+          route_destinations = ["infra1"]
+        }
+      }
+      "infra1" = {
+        public_subnets       = 0
+        private_subnets      = 2
+        vpc_cidr_subnet_mask = 16
+        subnet_mask          = 24
+        additional_private_subnets   = {
+          "db" = {
+            subnet_count = 2
+            nacl_rules = [
+              {
+                rule_number = 10
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "infra1"
+                from_port   = 3306
+                to_port     = 3306
+              },
+              {
+                rule_number = 20
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "ipam_account_pool"
+                from_port   = 1024
+                to_port     = 65535
+              },
+              {
+                rule_number = 10
+                egress      = true
+                action      = "allow"
+                protocol    = -1
+                cidr_block  = "ipam_account_pool"
+                from_port   = 0
+                to_port     = 0
+              }
+            ]
+          }
+        }
+        public_subnet_nacl_rules = [
+          {
+            rule_number = 10
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 443
+            to_port     = 443
+          },
+          {
+            rule_number = 20
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 80
+            to_port     = 80
+          },
+          {
+            rule_number = 30
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 1024
+            to_port     = 65535
+          },
+          {
+            rule_number = 10
+            egress      = true
+            action      = "allow"
+            protocol    = -1
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 0
+            to_port     = 0
+          }
+        ]
+        private_subnet_nacl_rules = [
+          {
+            rule_number = 10
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 1024
+            to_port     = 65535
+          },
+          {
+            rule_number = 20
+            egress      = false
+            action      = "allow"
+            protocol    = 6
+            cidr_block  = "egress"
+            from_port   = 22
+            to_port     = 22
+          },
+          {
+            rule_number = 10
+            egress      = true
+            action      = "allow"
+            protocol    = -1
+            cidr_block  = "0.0.0.0/0"
+            from_port   = 0
+            to_port     = 0
+          }
+        ]
+        gw_services = {
+          igw_is_enabled       = false
+          nat_gw_is_enabled    = false
+          nat_gw_type          = "private"
+          nat_gw_ha            = false
+          vpc_gateway_services = []
+          vpc_interface_services = [
+            "ec2", "sts"
+          ]
+          vpc_interface_services_scope = "private"
+        }
+        tgw_config = {
+          route_destinations = ["0.0.0.0/0"]
+        }
+      }
+    }
+    transit_gw = {
+      tgw_is_enabled = true
+      tgw_vpc_attach = ["infra1", "egress"]
+      tgw_routes = [
+        {
+          "destination" = "0.0.0.0/0"
+          "vpc_attachment"  = "egress"
+        }
+      ]
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws-networking" {
+  source  = "../"
+  project_name = local.project_name
+  environment = local.environment
+  parent_pool_cidr_block = local.parent_pool_cidr_block
+  network_config = local.network_config
+}

--- a/example/main.tf
+++ b/example/main.tf
@@ -5,11 +5,11 @@ locals {
   network_config = {
     vpcs = {
       "egress" = {
-        public_subnets       = 2
-        private_subnets      = 2
-        vpc_cidr_subnet_mask = 16
-        subnet_mask          = 24
-        additional_private_subnets   = {}
+        public_subnets             = 2
+        private_subnets            = 2
+        vpc_cidr_subnet_mask       = 16
+        subnet_mask                = 24
+        additional_private_subnets = {}
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -88,7 +88,7 @@ locals {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 16
         subnet_mask          = 24
-        additional_private_subnets   = {
+        additional_private_subnets = {
           "db" = {
             subnet_count = 2
             nacl_rules = [
@@ -210,8 +210,8 @@ locals {
       tgw_vpc_attach = ["infra1", "egress"]
       tgw_routes = [
         {
-          "destination" = "0.0.0.0/0"
-          "vpc_attachment"  = "egress"
+          "destination"    = "0.0.0.0/0"
+          "vpc_attachment" = "egress"
         }
       ]
     }
@@ -223,9 +223,9 @@ provider "aws" {
 }
 
 module "aws-networking" {
-  source  = "../"
-  project_name = local.project_name
-  environment = local.environment
+  source                 = "../"
+  project_name           = local.project_name
+  environment            = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
-  network_config = local.network_config
+  network_config         = local.network_config
 }

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,13 @@ module "aws-vpc" {
   route_table_per_private = each.value.gw_services.nat_gw_ha
   vpc_cidr_subnet_mask    = each.value.vpc_cidr_subnet_mask
   subnet_mask             = each.value.subnet_mask
+  additional_private_subnets = flatten([
+    for subnet in each.value.additional_private_subnets : [
+      for i in range(subnet.subnet_count) : [
+        "${each.key}${i + 1}::${i}"
+      ]
+    ]
+  ])
 }
 
 # Create NACLs for VPCs

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,10 @@ module "aws-vpc" {
   route_table_per_private = each.value.gw_services.nat_gw_ha
   vpc_cidr_subnet_mask    = each.value.vpc_cidr_subnet_mask
   subnet_mask             = each.value.subnet_mask
+  # Additional private subnets will encode a format that informs the:
+  # 1. Subnet Group
+  # 2. Subnet Index
+  # 3. Subnet Count for Group
   additional_private_subnets = flatten([
     for k, v in each.value.additional_private_subnets : [
       for i in range(v.subnet_count) : [

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,11 @@ module "aws-vpc-gw" {
   vpc_name                        = each.key
   vpc_id                          = module.aws-vpc[each.key].vpc_id
   public_subnet_ids               = module.aws-vpc[each.key].public_subnet_ids
-  private_subnet_ids              = module.aws-vpc[each.key].private_subnet_ids
+  private_subnet_ids              = concat(module.aws-vpc[each.key].private_subnet_ids, flatten([
+    for k, v in module.aws-vpc[each.key].additional_private_subnet_ids : [
+      for sn in v : sn
+    ]
+  ]))
   public_route_table_id           = module.aws-vpc[each.key].public_route_table_id
   private_route_table_ids         = module.aws-vpc[each.key].private_route_table_ids
   igw_is_enabled                  = each.value.gw_services.igw_is_enabled
@@ -144,8 +148,12 @@ module "aws-vpc-tgw" {
   vpcs = {
     for vpc in var.network_config.transit_gw.tgw_vpc_attach : vpc => {
       vpc_id             = module.aws-vpc[vpc].vpc_id
-      private_subnet_ids = module.aws-vpc[vpc].private_subnet_ids
       public_subnet_ids  = module.aws-vpc[vpc].public_subnet_ids
+      private_subnet_ids = concat(module.aws-vpc[vpc].private_subnet_ids, flatten([
+        for k, v in module.aws-vpc[vpc].additional_private_subnet_ids : [
+          for sn in v : sn
+        ]
+      ]))
     }
   }
   # Setup route table routes for a many to many relationship due to HA

--- a/main.tf
+++ b/main.tf
@@ -118,14 +118,14 @@ module "aws-nacl" {
 
 # Setup IGW and NAT Gateway
 module "aws-vpc-gw" {
-  source            = "./modules/aws-vpc-gw"
-  depends_on        = [module.aws-vpc]
-  for_each          = var.network_config.vpcs
-  project_name      = var.project_name
-  environment       = var.environment
-  vpc_name          = each.key
-  vpc_id            = module.aws-vpc[each.key].vpc_id
-  public_subnet_ids = module.aws-vpc[each.key].public_subnet_ids
+  source             = "./modules/aws-vpc-gw"
+  depends_on         = [module.aws-vpc]
+  for_each           = var.network_config.vpcs
+  project_name       = var.project_name
+  environment        = var.environment
+  vpc_name           = each.key
+  vpc_id             = module.aws-vpc[each.key].vpc_id
+  public_subnet_ids  = module.aws-vpc[each.key].public_subnet_ids
   private_subnet_ids = module.aws-vpc[each.key].private_subnet_ids
   additional_private_subnet_ids = flatten([
     for k, v in module.aws-vpc[each.key].additional_private_subnet_ids : [
@@ -152,11 +152,11 @@ module "aws-vpc-tgw" {
   environment  = var.environment
   vpcs = {
     for vpc in var.network_config.transit_gw.tgw_vpc_attach : vpc => {
-      vpc_id            = module.aws-vpc[vpc].vpc_id
-      public_subnet_ids = module.aws-vpc[vpc].public_subnet_ids
+      vpc_id             = module.aws-vpc[vpc].vpc_id
+      public_subnet_ids  = module.aws-vpc[vpc].public_subnet_ids
       private_subnet_ids = module.aws-vpc[vpc].private_subnet_ids
       additional_private_subnet_ids = flatten([
-        for k, v in  module.aws-vpc[vpc].additional_private_subnet_ids : [
+        for k, v in module.aws-vpc[vpc].additional_private_subnet_ids : [
           for sn in v : sn
         ]
       ])

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ module "aws-vpc" {
   additional_private_subnets = flatten([
     for subnet in each.value.additional_private_subnets : [
       for i in range(subnet.subnet_count) : [
-        "${each.key}${i + 1}::${i}"
+        "${each.key}::${i + 1}::${i}"
       ]
     ]
   ])

--- a/main.tf
+++ b/main.tf
@@ -126,11 +126,12 @@ module "aws-vpc-gw" {
   vpc_name          = each.key
   vpc_id            = module.aws-vpc[each.key].vpc_id
   public_subnet_ids = module.aws-vpc[each.key].public_subnet_ids
-  private_subnet_ids = concat(module.aws-vpc[each.key].private_subnet_ids, flatten([
+  private_subnet_ids = module.aws-vpc[each.key].private_subnet_ids
+  additional_private_subnet_ids = flatten([
     for k, v in module.aws-vpc[each.key].additional_private_subnet_ids : [
       for sn in v : sn
     ]
-  ]))
+  ])
   public_route_table_id           = module.aws-vpc[each.key].public_route_table_id
   private_route_table_ids         = module.aws-vpc[each.key].private_route_table_ids
   igw_is_enabled                  = each.value.gw_services.igw_is_enabled
@@ -153,11 +154,12 @@ module "aws-vpc-tgw" {
     for vpc in var.network_config.transit_gw.tgw_vpc_attach : vpc => {
       vpc_id            = module.aws-vpc[vpc].vpc_id
       public_subnet_ids = module.aws-vpc[vpc].public_subnet_ids
-      private_subnet_ids = concat(module.aws-vpc[vpc].private_subnet_ids, flatten([
-        for k, v in module.aws-vpc[vpc].additional_private_subnet_ids : [
+      private_subnet_ids = module.aws-vpc[vpc].private_subnet_ids
+      additional_private_subnet_ids = flatten([
+        for k, v in  module.aws-vpc[vpc].additional_private_subnet_ids : [
           for sn in v : sn
         ]
-      ]))
+      ])
     }
   }
   # Setup route table routes for a many to many relationship due to HA

--- a/main.tf
+++ b/main.tf
@@ -62,22 +62,22 @@ module "aws-vpc" {
 
 # Create NACLs for VPCs
 module "aws-nacl" {
-  source             = "./modules/aws-nacl"
-  depends_on         = [module.aws-vpc]
-  for_each           = var.network_config.vpcs
-  project_name       = var.project_name
-  environment        = var.environment
-  vpc_name           = each.key
-  vpc_id             = module.aws-vpc[each.key].vpc_id
-  public_subnet_ids  = module.aws-vpc[each.key].public_subnet_ids
-  private_subnet_ids = module.aws-vpc[each.key].private_subnet_ids
+  source                        = "./modules/aws-nacl"
+  depends_on                    = [module.aws-vpc]
+  for_each                      = var.network_config.vpcs
+  project_name                  = var.project_name
+  environment                   = var.environment
+  vpc_name                      = each.key
+  vpc_id                        = module.aws-vpc[each.key].vpc_id
+  public_subnet_ids             = module.aws-vpc[each.key].public_subnet_ids
+  private_subnet_ids            = module.aws-vpc[each.key].private_subnet_ids
   additional_private_subnet_ids = module.aws-vpc[each.key].additional_private_subnet_ids
   additional_private_subnet_associations = flatten([
     for k, v in module.aws-vpc[each.key].additional_private_subnet_ids : [
       for sn in v : {
-        subnet_id = sn
+        subnet_id    = sn
         subnet_group = k
-      } 
+      }
     ]
   ])
   public_subnet_nacl_rules = [for rule in each.value.public_subnet_nacl_rules : {
@@ -118,15 +118,15 @@ module "aws-nacl" {
 
 # Setup IGW and NAT Gateway
 module "aws-vpc-gw" {
-  source                          = "./modules/aws-vpc-gw"
-  depends_on                      = [module.aws-vpc]
-  for_each                        = var.network_config.vpcs
-  project_name                    = var.project_name
-  environment                     = var.environment
-  vpc_name                        = each.key
-  vpc_id                          = module.aws-vpc[each.key].vpc_id
-  public_subnet_ids               = module.aws-vpc[each.key].public_subnet_ids
-  private_subnet_ids              = concat(module.aws-vpc[each.key].private_subnet_ids, flatten([
+  source            = "./modules/aws-vpc-gw"
+  depends_on        = [module.aws-vpc]
+  for_each          = var.network_config.vpcs
+  project_name      = var.project_name
+  environment       = var.environment
+  vpc_name          = each.key
+  vpc_id            = module.aws-vpc[each.key].vpc_id
+  public_subnet_ids = module.aws-vpc[each.key].public_subnet_ids
+  private_subnet_ids = concat(module.aws-vpc[each.key].private_subnet_ids, flatten([
     for k, v in module.aws-vpc[each.key].additional_private_subnet_ids : [
       for sn in v : sn
     ]
@@ -151,8 +151,8 @@ module "aws-vpc-tgw" {
   environment  = var.environment
   vpcs = {
     for vpc in var.network_config.transit_gw.tgw_vpc_attach : vpc => {
-      vpc_id             = module.aws-vpc[vpc].vpc_id
-      public_subnet_ids  = module.aws-vpc[vpc].public_subnet_ids
+      vpc_id            = module.aws-vpc[vpc].vpc_id
+      public_subnet_ids = module.aws-vpc[vpc].public_subnet_ids
       private_subnet_ids = concat(module.aws-vpc[vpc].private_subnet_ids, flatten([
         for k, v in module.aws-vpc[vpc].additional_private_subnet_ids : [
           for sn in v : sn

--- a/modules/aws-nacl/main.tf
+++ b/modules/aws-nacl/main.tf
@@ -35,7 +35,7 @@ resource "aws_network_acl" "private_subnet_nacl" {
 
 resource "aws_network_acl" "additional_private_subnet_nacl" {
   for_each = var.additional_private_subnet_ids
-  vpc_id = var.vpc_id
+  vpc_id   = var.vpc_id
   tags = {
     Name = "${var.project_name}-${var.environment}-${var.vpc_name}-private-subnet-${each.key}-nacl"
   }

--- a/modules/aws-nacl/main.tf
+++ b/modules/aws-nacl/main.tf
@@ -33,6 +33,14 @@ resource "aws_network_acl" "private_subnet_nacl" {
   }
 }
 
+resource "aws_network_acl" "additional_private_subnet_nacl" {
+  for_each = var.additional_private_subnet_ids
+  vpc_id = var.vpc_id
+  tags = {
+    Name = "${var.project_name}-${var.environment}-${var.vpc_name}-private-subnet-${each.key}-nacl"
+  }
+}
+
 resource "aws_network_acl_rule" "public_subnet_nacl_rules" {
   count          = length(var.public_subnet_ids) > 0 ? length(var.public_subnet_nacl_rules) : 0
   network_acl_id = length(aws_network_acl.public_subnet_nacl) > 0 ? aws_network_acl.public_subnet_nacl[0].id : ""
@@ -71,6 +79,25 @@ resource "aws_network_acl_rule" "private_subnet_nacl_rules" {
   }
 }
 
+resource "aws_network_acl_rule" "additional_private_subnet_nacl_rules" {
+  count          = length(var.additional_private_subnet_nacl_rules) > 0 ? length(var.additional_private_subnet_nacl_rules) : 0
+  network_acl_id = aws_network_acl.additional_private_subnet_nacl[var.additional_private_subnet_nacl_rules[count.index].subnet].id
+  rule_number    = var.additional_private_subnet_nacl_rules[count.index].rule_number
+  egress         = var.additional_private_subnet_nacl_rules[count.index].egress
+  protocol       = var.additional_private_subnet_nacl_rules[count.index].protocol
+  rule_action    = var.additional_private_subnet_nacl_rules[count.index].action
+  cidr_block     = var.additional_private_subnet_nacl_rules[count.index].cidr_block
+  from_port      = var.additional_private_subnet_nacl_rules[count.index].from_port
+  to_port        = var.additional_private_subnet_nacl_rules[count.index].to_port
+  depends_on     = [aws_network_acl.additional_private_subnet_nacl]
+  lifecycle {
+    precondition {
+      condition     = can(cidrsubnet(var.additional_private_subnet_nacl_rules[count.index].cidr_block, 0, 0))
+      error_message = "Invalid NACL rule CIDR block. Ensure shorthand names are referenced correctly in rules to valid VPC names or ipam_account_pool."
+    }
+  }
+}
+
 # Associate NACL with public and private subnets
 resource "aws_network_acl_association" "public_subnet_nacl_association" {
   count          = length(var.public_subnet_ids)
@@ -84,4 +111,11 @@ resource "aws_network_acl_association" "private_subnet_nacl_association" {
   subnet_id      = var.private_subnet_ids[count.index]
   network_acl_id = length(aws_network_acl.private_subnet_nacl) > 0 ? aws_network_acl.private_subnet_nacl[0].id : ""
   depends_on     = [aws_network_acl.private_subnet_nacl]
+}
+
+resource "aws_network_acl_association" "additional_private_subnet_nacl_association" {
+  count          = length(var.additional_private_subnet_associations)
+  subnet_id      = var.additional_private_subnet_associations[count.index].subnet_id
+  network_acl_id = aws_network_acl.additional_private_subnet_nacl[var.additional_private_subnet_associations[count.index].subnet_group].id
+  depends_on     = [aws_network_acl.additional_private_subnet_nacl]
 }

--- a/modules/aws-nacl/tests/nacl_module.tftest.hcl
+++ b/modules/aws-nacl/tests/nacl_module.tftest.hcl
@@ -7,6 +7,7 @@ variables {
   vpc_id             = "vpc-afwpeoijwegt"
   public_subnet_ids  = ["sub1", "sub2"]
   private_subnet_ids = ["sub3", "sub4"]
+  additional_private_subnet_ids = {}
   public_subnet_nacl_rules = [
     {
       rule_number = 10
@@ -47,6 +48,7 @@ variables {
       to_port     = 0
     },
   ]
+  additional_private_subnet_nacl_rules = []
 }
 
 run "positive_standard_config" {
@@ -103,6 +105,71 @@ run "positive_no_private_subnets" {
   assert {
     condition     = length(aws_network_acl_rule.private_subnet_nacl_rules) == 0
     error_message = "Expected 0 Private NACL Rules"
+  }
+
+}
+
+run "positive_additional_private_nacl" {
+  command = plan
+
+  variables {
+    additional_private_subnet_ids = {
+      "db" = ["sub5", "sub6"]
+    }
+  }
+
+  assert {
+    condition     = length(aws_network_acl.additional_private_subnet_nacl) == 1
+    error_message = "Expected 2 Network ACLS"
+  }
+
+}
+
+run "positive_additional_private_nacl_rules" {
+  command = plan
+
+  variables {
+    additional_private_subnet_ids = {
+      "db" = ["sub5", "sub6"]
+    }
+    additional_private_subnet_nacl_rules = [
+      {
+        rule_number = 10
+        egress      = false
+        action      = "allow"
+        protocol    = 6
+        cidr_block  = "10.0.0.0/8"
+        from_port   = 80
+        to_port     = 80
+        subnet      = "db"
+      },
+      {
+        rule_number = 10
+        egress      = true
+        action      = "allow"
+        protocol    = -1
+        cidr_block  = "0.0.0.0/0"
+        from_port   = 0
+        to_port     = 0
+        subnet      = "db"
+      },
+    ]
+    additional_private_subnet_associations = [
+      {
+        subnet_id = "sub5"
+        subnet_group = "db"
+      },
+      {
+        subnet_id = "sub6"
+        subnet_group = "db"
+      }
+    ]
+  }
+
+
+  assert {
+    condition     = length(aws_network_acl_rule.additional_private_subnet_nacl_rules) == 2
+    error_message = "Expected 2 Network ACL Rules"
   }
 
 }
@@ -167,6 +234,53 @@ run "negative_invalid_private_rule_cidr" {
 
   expect_failures = [
     aws_network_acl_rule.private_subnet_nacl_rules
+  ]
+
+}
+
+run "negative_invalid_additional_private_rule_cidr" {
+  command = plan
+
+  variables {
+    additional_private_subnet_ids = {
+      "db" = ["sub5", "sub6"]
+    }
+    additional_private_subnet_nacl_rules = [
+      {
+        rule_number = 10
+        egress      = false
+        action      = "allow"
+        protocol    = 6
+        cidr_block  = "infra1"
+        from_port   = 80
+        to_port     = 80
+        subnet      = "db"
+      },
+      {
+        rule_number = 10
+        egress      = true
+        action      = "allow"
+        protocol    = -1
+        cidr_block  = "0.0.0.0/0"
+        from_port   = 0
+        to_port     = 0
+        subnet      = "db"
+      },
+    ]
+    additional_private_subnet_associations = [
+      {
+        subnet_id = "sub5"
+        subnet_group = "db"
+      },
+      {
+        subnet_id = "sub6"
+        subnet_group = "db"
+      }
+    ]
+  }
+
+  expect_failures = [
+    aws_network_acl_rule.additional_private_subnet_nacl_rules
   ]
 
 }

--- a/modules/aws-nacl/tests/nacl_module.tftest.hcl
+++ b/modules/aws-nacl/tests/nacl_module.tftest.hcl
@@ -1,12 +1,12 @@
 mock_provider "aws" {}
 
 variables {
-  project_name       = "projecta"
-  environment        = "test"
-  vpc_name           = "infra1"
-  vpc_id             = "vpc-afwpeoijwegt"
-  public_subnet_ids  = ["sub1", "sub2"]
-  private_subnet_ids = ["sub3", "sub4"]
+  project_name                  = "projecta"
+  environment                   = "test"
+  vpc_name                      = "infra1"
+  vpc_id                        = "vpc-afwpeoijwegt"
+  public_subnet_ids             = ["sub1", "sub2"]
+  private_subnet_ids            = ["sub3", "sub4"]
   additional_private_subnet_ids = {}
   public_subnet_nacl_rules = [
     {
@@ -156,11 +156,11 @@ run "positive_additional_private_nacl_rules" {
     ]
     additional_private_subnet_associations = [
       {
-        subnet_id = "sub5"
+        subnet_id    = "sub5"
         subnet_group = "db"
       },
       {
-        subnet_id = "sub6"
+        subnet_id    = "sub6"
         subnet_group = "db"
       }
     ]
@@ -269,11 +269,11 @@ run "negative_invalid_additional_private_rule_cidr" {
     ]
     additional_private_subnet_associations = [
       {
-        subnet_id = "sub5"
+        subnet_id    = "sub5"
         subnet_group = "db"
       },
       {
-        subnet_id = "sub6"
+        subnet_id    = "sub6"
         subnet_group = "db"
       }
     ]

--- a/modules/aws-nacl/variables.tf
+++ b/modules/aws-nacl/variables.tf
@@ -22,6 +22,12 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+variable "additional_private_subnet_ids" {
+  description = "Additional Private Subnet IDs"
+  type        = map(list(string))
+  default = {}
+}
+
 variable "public_subnet_nacl_rules" {
   description = "Public Subnet NACL Rules"
   type = list(object({
@@ -46,6 +52,30 @@ variable "private_subnet_nacl_rules" {
     cidr_block  = string
     from_port   = number
     to_port     = number
+  }))
+  default = []
+}
+
+variable "additional_private_subnet_nacl_rules" {
+  description = "Additional Private Subnet NACL Rules"
+  type = list(object({
+    rule_number = number
+    egress      = bool
+    action      = string
+    protocol    = string
+    cidr_block  = string
+    from_port   = number
+    to_port     = number
+    subnet      = string
+  }))
+  default = []
+}
+
+variable "additional_private_subnet_associations" {
+  description = "Additional Private Subnet Associations"
+  type = list(object({
+    subnet_id = string
+    subnet_group = string
   }))
   default = []
 }

--- a/modules/aws-nacl/variables.tf
+++ b/modules/aws-nacl/variables.tf
@@ -25,7 +25,7 @@ variable "private_subnet_ids" {
 variable "additional_private_subnet_ids" {
   description = "Additional Private Subnet IDs"
   type        = map(list(string))
-  default = {}
+  default     = {}
 }
 
 variable "public_subnet_nacl_rules" {
@@ -74,7 +74,7 @@ variable "additional_private_subnet_nacl_rules" {
 variable "additional_private_subnet_associations" {
   description = "Additional Private Subnet Associations"
   type = list(object({
-    subnet_id = string
+    subnet_id    = string
     subnet_group = string
   }))
   default = []

--- a/modules/aws-vpc-gw/variables.tf
+++ b/modules/aws-vpc-gw/variables.tf
@@ -18,6 +18,12 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+variable "additional_private_subnet_ids" {
+  description = "Additional Private Subnet IDs"
+  type        = list(string)
+  default     = []
+}
+
 variable "public_route_table_id" {
   description = "Public Route Table ID"
   type        = string

--- a/modules/aws-vpc-tgw/variables.tf
+++ b/modules/aws-vpc-tgw/variables.tf
@@ -5,7 +5,8 @@ variable "vpcs" {
       {
         vpc_id             = string,
         private_subnet_ids = list(string),
-        public_subnet_ids  = list(string)
+        public_subnet_ids  = list(string),
+        additional_private_subnet_ids = list(string)
       }
     )
   )

--- a/modules/aws-vpc-tgw/variables.tf
+++ b/modules/aws-vpc-tgw/variables.tf
@@ -3,9 +3,9 @@ variable "vpcs" {
   type = map(
     object(
       {
-        vpc_id             = string,
-        private_subnet_ids = list(string),
-        public_subnet_ids  = list(string),
+        vpc_id                        = string,
+        private_subnet_ids            = list(string),
+        public_subnet_ids             = list(string),
         additional_private_subnet_ids = list(string)
       }
     )

--- a/modules/aws-vpc/main.tf
+++ b/modules/aws-vpc/main.tf
@@ -89,7 +89,7 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "vpc_ipam_pool_private" {
 resource "aws_vpc_ipam_pool_cidr_allocation" "vpc_ipam_pool_additional_private" {
   for_each       = toset(var.additional_private_subnets)
   ipam_pool_id   = aws_vpc_ipam_pool.vpc_subnet_ipam_pool.id
-  description    = "${var.project_name}-${var.environment}-vpc-${var.vpc_name}-private-subnet-${split("::", each.value)[0]}"
+  description    = "${var.project_name}-${var.environment}-vpc-${var.vpc_name}-private-subnet-${split("::", each.value)[0]}-${split("::", each.value)[1]}"
   netmask_length = var.subnet_mask
 
   depends_on = [
@@ -145,9 +145,9 @@ resource "aws_subnet" "additional_private_subnet" {
   for_each          = toset(var.additional_private_subnets)
   vpc_id            = aws_vpc.vpc_network.id
   cidr_block        = aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_additional_private[each.value].cidr
-  availability_zone = data.aws_availability_zones.available.names[split("::", each.value)[1]]
+  availability_zone = data.aws_availability_zones.available.names[split("::", each.value)[2]]
   tags = {
-    Name = "${var.project_name}-${var.environment}-vpc-${var.vpc_name}-private-subnet-${split("::", each.value)[0]}"
+    Name = "${var.project_name}-${var.environment}-vpc-${var.vpc_name}-private-subnet-${split("::", each.value)[0]}-${split("::", each.value)[1]}"
   }
   depends_on = [aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_additional_private]
 }
@@ -185,7 +185,7 @@ resource "aws_route_table_association" "private_subnet_association" {
 resource "aws_route_table_association" "additional_private_subnet_association" {
   for_each       = toset(var.additional_private_subnets)
   subnet_id      = aws_subnet.additional_private_subnet[each.value].id
-  route_table_id = var.route_table_per_private ? aws_route_table.private_route_table[split("::", each.value)[1]].id : aws_route_table.private_route_table[0].id
+  route_table_id = var.route_table_per_private ? aws_route_table.private_route_table[split("::", each.value)[2]].id : aws_route_table.private_route_table[0].id
 }
 
 # Create Default VPC Security Group

--- a/modules/aws-vpc/main.tf
+++ b/modules/aws-vpc/main.tf
@@ -86,6 +86,27 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "vpc_ipam_pool_private" {
   }
 }
 
+resource "aws_vpc_ipam_pool_cidr_allocation" "vpc_ipam_pool_additional_private" {
+  for_each       = toset(var.additional_private_subnets)
+  ipam_pool_id   = aws_vpc_ipam_pool.vpc_subnet_ipam_pool.id
+  description    = "${var.project_name}-${var.environment}-vpc-${var.vpc_name}-private-subnet-${split("::", each.value)[0]}"
+  netmask_length = var.subnet_mask
+
+  depends_on = [
+    aws_vpc_ipam_pool.vpc_subnet_ipam_pool,
+    aws_vpc_ipam_pool_cidr.vpc_subnet_ipam_pool_cidr,
+    aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_public,
+    aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_private
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = var.subnet_mask > var.vpc_cidr_subnet_mask
+      error_message = "Subnet mask must be greater than VPC CIDR subnet mask."
+    }
+  }
+}
+
 # Create VPC with input CIDR block
 resource "aws_vpc" "vpc_network" {
   cidr_block           = aws_vpc_ipam_pool_cidr.vpc_subnet_ipam_pool_cidr.cidr
@@ -120,6 +141,17 @@ resource "aws_subnet" "private_subnet" {
   depends_on = [aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_private]
 }
 
+resource "aws_subnet" "additional_private_subnet" {
+  for_each          = toset(var.additional_private_subnets)
+  vpc_id            = aws_vpc.vpc_network.id
+  cidr_block        = aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_additional_private[each.value].cidr
+  availability_zone = data.aws_availability_zones.available.names[split("::", each.value)[1]]
+  tags = {
+    Name = "${var.project_name}-${var.environment}-vpc-${var.vpc_name}-private-subnet-${split("::", each.value)[0]}"
+  }
+  depends_on = [aws_vpc_ipam_pool_cidr_allocation.vpc_ipam_pool_additional_private]
+}
+
 # Create the public/private route tables
 # TODO Check for count of public subnets and if 0 don't create RT
 resource "aws_route_table" "public_route_table" {
@@ -148,6 +180,12 @@ resource "aws_route_table_association" "private_subnet_association" {
   count          = var.private_subnets
   subnet_id      = aws_subnet.private_subnet[count.index].id
   route_table_id = var.route_table_per_private ? aws_route_table.private_route_table[count.index].id : aws_route_table.private_route_table[0].id
+}
+
+resource "aws_route_table_association" "additional_private_subnet_association" {
+  for_each       = toset(var.additional_private_subnets)
+  subnet_id      = aws_subnet.additional_private_subnet[each.value].id
+  route_table_id = var.route_table_per_private ? aws_route_table.private_route_table[split("::", each.value)[1]].id : aws_route_table.private_route_table[0].id
 }
 
 # Create Default VPC Security Group

--- a/modules/aws-vpc/outputs.tf
+++ b/modules/aws-vpc/outputs.tf
@@ -25,7 +25,7 @@ output "private_subnet_ids" {
 
 output "additional_private_subnet_ids" {
   description = "Additional Private Subnet IDs"
-  value       = {
+  value = {
     for subnet_group in flatten(distinct([for l in var.additional_private_subnets : split("::", l)[0]])) : subnet_group => flatten([
       for subnet in var.additional_private_subnets : [
         split("::", subnet_group)[0] == split("::", subnet)[0] ? aws_subnet.additional_private_subnet[subnet].id : null

--- a/modules/aws-vpc/outputs.tf
+++ b/modules/aws-vpc/outputs.tf
@@ -23,6 +23,13 @@ output "private_subnet_ids" {
   value       = aws_subnet.private_subnet[*].id
 }
 
+output "additional_private_subnet_ids" {
+  description = "Additional Private Subnet IDs"
+  value       = {
+    for subnet in var.additional_private_subnets : split("::", subnet)[0] => aws_subnet.additional_private_subnet[subnet].id
+  }
+}
+
 output "public_availability_zones" {
   description = "Public Availability Zones"
   value       = aws_subnet.public_subnet[*].availability_zone

--- a/modules/aws-vpc/outputs.tf
+++ b/modules/aws-vpc/outputs.tf
@@ -26,7 +26,11 @@ output "private_subnet_ids" {
 output "additional_private_subnet_ids" {
   description = "Additional Private Subnet IDs"
   value       = {
-    for subnet in var.additional_private_subnets : split("::", subnet)[0] => aws_subnet.additional_private_subnet[subnet].id
+    for subnet_group in flatten(distinct([for l in var.additional_private_subnets : split("::", l)[0]])) : subnet_group => flatten([
+      for subnet in var.additional_private_subnets : [
+        split("::", subnet_group)[0] == split("::", subnet)[0] ? aws_subnet.additional_private_subnet[subnet].id : null
+      ]
+    ])
   }
 }
 

--- a/modules/aws-vpc/tests/vpc_module.tftest.hcl
+++ b/modules/aws-vpc/tests/vpc_module.tftest.hcl
@@ -18,6 +18,7 @@ variables {
   route_table_per_private = false
   vpc_cidr_subnet_mask    = 16
   subnet_mask             = 24
+  additional_private_subnets = []
 }
 
 run "positive_standard_config" {
@@ -54,6 +55,20 @@ run "positive_no_public_subnets" {
   assert {
     condition     = length(aws_subnet.public_subnet) == 0 && length(aws_subnet.private_subnet) == 2
     error_message = "Expected 0 Public and 2 Private Subnets Created"
+  }
+
+}
+
+run "positive_additional_private" {
+  command = plan
+
+  variables {
+    additional_private_subnets = ["db1::0", "db2::1"]
+  }
+
+  assert {
+    condition     = lookup(aws_subnet.additional_private_subnet, "db1::0", "default") != "default" && lookup(aws_subnet.additional_private_subnet, "db2::1", "default") != "default"
+    error_message = "Expected 2 DB Subnets Created"
   }
 
 }

--- a/modules/aws-vpc/tests/vpc_module.tftest.hcl
+++ b/modules/aws-vpc/tests/vpc_module.tftest.hcl
@@ -63,11 +63,11 @@ run "positive_additional_private" {
   command = plan
 
   variables {
-    additional_private_subnets = ["db1::0", "db2::1"]
+    additional_private_subnets = ["db::1::0", "db::2::1"]
   }
 
   assert {
-    condition     = lookup(aws_subnet.additional_private_subnet, "db1::0", "default") != "default" && lookup(aws_subnet.additional_private_subnet, "db2::1", "default") != "default"
+    condition     = lookup(aws_subnet.additional_private_subnet, "db::1::0", "default") != "default" && lookup(aws_subnet.additional_private_subnet, "db::2::1", "default") != "default"
     error_message = "Expected 2 DB Subnets Created"
   }
 

--- a/modules/aws-vpc/tests/vpc_module.tftest.hcl
+++ b/modules/aws-vpc/tests/vpc_module.tftest.hcl
@@ -7,17 +7,17 @@ mock_provider "aws" {
 }
 
 variables {
-  project_name            = "projecta"
-  environment             = "test"
-  vpc_name                = "infra1"
-  acct_ipam_scope_id      = "ipam-awefkanewgaweg"
-  acct_ipam_pool_id       = "ipam-awepfoinaerg"
-  acct_ipam_pool_cidr     = "10.0.0.0/8"
-  public_subnets          = 2
-  private_subnets         = 2
-  route_table_per_private = false
-  vpc_cidr_subnet_mask    = 16
-  subnet_mask             = 24
+  project_name               = "projecta"
+  environment                = "test"
+  vpc_name                   = "infra1"
+  acct_ipam_scope_id         = "ipam-awefkanewgaweg"
+  acct_ipam_pool_id          = "ipam-awepfoinaerg"
+  acct_ipam_pool_cidr        = "10.0.0.0/8"
+  public_subnets             = 2
+  private_subnets            = 2
+  route_table_per_private    = false
+  vpc_cidr_subnet_mask       = 16
+  subnet_mask                = 24
   additional_private_subnets = []
 }
 

--- a/modules/aws-vpc/variables.tf
+++ b/modules/aws-vpc/variables.tf
@@ -54,6 +54,11 @@ variable "private_subnets" {
   }
 }
 
+variable "additional_private_subnets" {
+  description = "Additional Private Subnets"
+  type        = list(string)
+}
+
 variable "route_table_per_private" {
   description = "Route Table per Private Subnet"
   type        = bool

--- a/tests/integration.tftest.hcl
+++ b/tests/integration.tftest.hcl
@@ -22,6 +22,7 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 24
         subnet_mask          = 27
+        additional_private_subnets   = {}
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -100,6 +101,40 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 24
         subnet_mask          = 27
+        additional_private_subnets   = {
+          "db" = {
+            subnet_count = 2
+            nacl_rules = [
+              {
+                rule_number = 10
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "infra1"
+                from_port   = 3306
+                to_port     = 3306
+              },
+              {
+                rule_number = 20
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "ipam_account_pool"
+                from_port   = 1024
+                to_port     = 65535
+              },
+              {
+                rule_number = 10
+                egress      = true
+                action      = "allow"
+                protocol    = -1
+                cidr_block  = "ipam_account_pool"
+                from_port   = 0
+                to_port     = 0
+              }
+            ]
+          }
+        }
         public_subnet_nacl_rules = [
           {
             rule_number = 10

--- a/tests/integration.tftest.hcl
+++ b/tests/integration.tftest.hcl
@@ -18,11 +18,11 @@ variables {
   network_config = {
     vpcs = {
       "egress" = {
-        public_subnets       = 2
-        private_subnets      = 2
-        vpc_cidr_subnet_mask = 24
-        subnet_mask          = 27
-        additional_private_subnets   = {}
+        public_subnets             = 2
+        private_subnets            = 2
+        vpc_cidr_subnet_mask       = 24
+        subnet_mask                = 27
+        additional_private_subnets = {}
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -101,7 +101,7 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 24
         subnet_mask          = 27
-        additional_private_subnets   = {
+        additional_private_subnets = {
           "db" = {
             subnet_count = 2
             nacl_rules = [

--- a/tests/integration.tftest.hcl
+++ b/tests/integration.tftest.hcl
@@ -20,7 +20,7 @@ variables {
       "egress" = {
         public_subnets             = 2
         private_subnets            = 2
-        vpc_cidr_subnet_mask       = 24
+        vpc_cidr_subnet_mask       = 22
         subnet_mask                = 27
         additional_private_subnets = {}
         public_subnet_nacl_rules = [

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -13,6 +13,7 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 24
         subnet_mask          = 27
+        additional_private_subnets   = {}
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -91,6 +92,40 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 24
         subnet_mask          = 27
+        additional_private_subnets   = {
+          "db" = {
+            subnet_count = 2
+            nacl_rules = [
+              {
+                rule_number = 10
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "infra1"
+                from_port   = 3306
+                to_port     = 3306
+              },
+              {
+                rule_number = 20
+                egress      = false
+                action      = "allow"
+                protocol    = 6
+                cidr_block  = "ipam_account_pool"
+                from_port   = 1024
+                to_port     = 65535
+              },
+              {
+                rule_number = 10
+                egress      = true
+                action      = "allow"
+                protocol    = -1
+                cidr_block  = "ipam_account_pool"
+                from_port   = 0
+                to_port     = 0
+              }
+            ]
+          }
+        }
         public_subnet_nacl_rules = [
           {
             rule_number = 10

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -9,11 +9,11 @@ variables {
   network_config = {
     vpcs = {
       "egress" = {
-        public_subnets       = 2
-        private_subnets      = 2
-        vpc_cidr_subnet_mask = 24
-        subnet_mask          = 27
-        additional_private_subnets   = {}
+        public_subnets             = 2
+        private_subnets            = 2
+        vpc_cidr_subnet_mask       = 24
+        subnet_mask                = 27
+        additional_private_subnets = {}
         public_subnet_nacl_rules = [
           {
             rule_number = 10
@@ -92,7 +92,7 @@ variables {
         private_subnets      = 2
         vpc_cidr_subnet_mask = 24
         subnet_mask          = 27
-        additional_private_subnets   = {
+        additional_private_subnets = {
           "db" = {
             subnet_count = 2
             nacl_rules = [

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -11,7 +11,7 @@ variables {
       "egress" = {
         public_subnets             = 2
         private_subnets            = 2
-        vpc_cidr_subnet_mask       = 24
+        vpc_cidr_subnet_mask       = 22
         subnet_mask                = 27
         additional_private_subnets = {}
         public_subnet_nacl_rules = [

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,18 @@ variable "network_config" {
         private_subnets      = number
         vpc_cidr_subnet_mask = number
         subnet_mask          = number
+        additional_private_subnets = map(object({
+          subnet_count   = number
+          nacl_rules     = list(object({
+            rule_number = number
+            egress      = bool
+            action      = string
+            protocol    = string
+            from_port   = number
+            to_port     = number
+            cidr_block  = string
+          }))
+        }))
         gw_services = object({
           igw_is_enabled               = bool
           nat_gw_is_enabled            = bool

--- a/variables.tf
+++ b/variables.tf
@@ -35,8 +35,8 @@ variable "network_config" {
         vpc_cidr_subnet_mask = number
         subnet_mask          = number
         additional_private_subnets = map(object({
-          subnet_count   = number
-          nacl_rules     = list(object({
+          subnet_count = number
+          nacl_rules = list(object({
             rule_number = number
             egress      = bool
             action      = string


### PR DESCRIPTION
Allow configuration of additional private subnets with NACL rules  that automatically associate with:
1. Private route table
2. Private GW and PrivateLink services
3. NAT GW
4. TGW association

Closes #9 