### PR TITLE
Add IPAM Scope ID Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ locals {
   project_name           = "projecta"
   environment            = "test"
   parent_pool_cidr_block = "10.0.0.0/8"
+  ipam_scope_id          = null
   network_config = {
     vpcs = {
       "egress" = {
@@ -241,10 +242,11 @@ provider "aws" {
 
 module "aws-networking" {
   source  = "stajkowski/networking/aws"
-  version = "2.0.0"
+  version = "2.1.0"
   project_name = local.project_name
   environment = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
+  ipam_scope_id          = local.ipam_scope_id
   network_config = local.network_config
 }
 ```
@@ -323,6 +325,8 @@ The following example will create:
 |-----------|-----------|-----------|
 | project_name | Generally referred to as the namespace. This can be any value used to identify the parent set of objects created in the environment. | `string`
 | environment | Current environment stage to configure.  This value is only utilized in naming resources and applying tags. | `string`
+| parent_pool_cidr_block | CIDR block for Environment Parent VPC Pools, i.e. 10.0.0.0/8. | `string`
+| ipam_scope_id | Existing IPAM scope ID for Environment VPC Parent Pool Creation.  Use standard ARN format for Scope ID. i.e. `ipam-scope-04dd36eca6021f93e`.  | `string`
 | network_config | Network configuration values utilized to standup VPC resources. | `object()`
 
 #### Network Configuration Inputs
@@ -530,3 +534,14 @@ The following example will create:
 ## License
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+## About
+[![text](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/brian-stajkowski-a99b9b5/)
+
+### Brian Stajkowski
+With over 20 years of experience in the IT industry from networking to building cloud services at massive scale, DevOps has been a continued interest.  Feel free to use any or all of the modules contained in this respository, and submit any use cases that further expand this abstraction in bulding complex virtual networks in AWS.  Connect with me on LiknkedIn!
+
+https://www.linkedin.com/in/brian-stajkowski-a99b9b5/
+
+![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)
+![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)

--- a/example/main.tf
+++ b/example/main.tf
@@ -2,6 +2,7 @@ locals {
   project_name           = "projecta"
   environment            = "test"
   parent_pool_cidr_block = "10.0.0.0/8"
+  ipam_scope_id          = null
   network_config = {
     vpcs = {
       "egress" = {
@@ -227,5 +228,6 @@ module "aws-networking" {
   project_name           = local.project_name
   environment            = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
+  ipam_scope_id          = local.ipam_scope_id
   network_config         = local.network_config
 }

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "aws-acct-ipam" {
   project_name           = var.project_name
   environment            = var.environment
   parent_pool_cidr_block = var.parent_pool_cidr_block
+  ipam_scope_id          = var.ipam_scope_id
 }
 
 # Create VPC with Public and Private Subnets

--- a/modules/aws-acct-ipam/main.tf
+++ b/modules/aws-acct-ipam/main.tf
@@ -18,7 +18,7 @@ data "aws_region" "current" {}
 
 #Create IPAM Scope for Account
 resource "aws_vpc_ipam" "region_ipam" {
-  count = var.ipam_scope_id == null ? 1 : 0
+  count       = var.ipam_scope_id == null ? 1 : 0
   description = "${var.project_name}-${var.environment}-account-ipan"
   operating_regions {
     region_name = data.aws_region.current.name

--- a/modules/aws-acct-ipam/main.tf
+++ b/modules/aws-acct-ipam/main.tf
@@ -18,6 +18,7 @@ data "aws_region" "current" {}
 
 #Create IPAM Scope for Account
 resource "aws_vpc_ipam" "region_ipam" {
+  count = var.ipam_scope_id == null ? 1 : 0
   description = "${var.project_name}-${var.environment}-account-ipan"
   operating_regions {
     region_name = data.aws_region.current.name
@@ -32,7 +33,7 @@ resource "aws_vpc_ipam_pool" "region_ipam_pool" {
   description                       = "${var.project_name}-${var.environment}-vpc-ipam-pool"
   address_family                    = "ipv4"
   allocation_default_netmask_length = 16
-  ipam_scope_id                     = aws_vpc_ipam.region_ipam.private_default_scope_id
+  ipam_scope_id                     = var.ipam_scope_id != null ? var.ipam_scope_id : aws_vpc_ipam.region_ipam[0].private_default_scope_id
 }
 
 resource "aws_vpc_ipam_pool_cidr" "acct_ipam_pool_cidr" {

--- a/modules/aws-acct-ipam/outputs.tf
+++ b/modules/aws-acct-ipam/outputs.tf
@@ -1,6 +1,6 @@
 output "acct_ipam_scope_id" {
   description = "Account IPAM Scope ID"
-  value       = aws_vpc_ipam.region_ipam.private_default_scope_id
+  value       = var.ipam_scope_id != null ? var.ipam_scope_id : aws_vpc_ipam.region_ipam[0].private_default_scope_id
 }
 
 output "acct_ipam_pool_id" {

--- a/modules/aws-acct-ipam/tests/ipam_module.tftest.hcl
+++ b/modules/aws-acct-ipam/tests/ipam_module.tftest.hcl
@@ -7,10 +7,10 @@ mock_provider "aws" {
 }
 
 variables {
-  project_name               = "projecta"
-  environment                = "test"
-  parent_pool_cidr_block     = "10.0.0.0/8"
-  ipam_scope_id              = null
+  project_name           = "projecta"
+  environment            = "test"
+  parent_pool_cidr_block = "10.0.0.0/8"
+  ipam_scope_id          = null
 }
 
 run "positive_standard_config" {
@@ -27,7 +27,7 @@ run "positive_ipam_scope_id_exists" {
   command = plan
 
   variables {
-    ipam_scope_id           = "ipam-scope-04dd36eca6021f93e"
+    ipam_scope_id = "ipam-scope-04dd36eca6021f93e"
   }
 
   assert {

--- a/modules/aws-acct-ipam/tests/ipam_module.tftest.hcl
+++ b/modules/aws-acct-ipam/tests/ipam_module.tftest.hcl
@@ -1,0 +1,38 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+}
+
+variables {
+  project_name               = "projecta"
+  environment                = "test"
+  parent_pool_cidr_block     = "10.0.0.0/8"
+  ipam_scope_id              = null
+}
+
+run "positive_standard_config" {
+  command = plan
+
+  assert {
+    condition     = length(aws_vpc_ipam.region_ipam) == 1
+    error_message = "Expected 1 IPAM Account ID Created"
+  }
+
+}
+
+run "positive_ipam_scope_id_exists" {
+  command = plan
+
+  variables {
+    ipam_scope_id           = "ipam-scope-04dd36eca6021f93e"
+  }
+
+  assert {
+    condition     = length(aws_vpc_ipam.region_ipam) == 0
+    error_message = "Expected 1 IPAM Account ID Created"
+  }
+
+}

--- a/modules/aws-acct-ipam/variables.tf
+++ b/modules/aws-acct-ipam/variables.tf
@@ -24,3 +24,9 @@ variable "environment" {
     error_message = "Environment should be alphanumeric, can contain hyphens, and not be empty"
   }
 }
+
+variable "ipam_scope_id" {
+  description = "Override IPAM Scope ID to use for VPC/Subnet Assignment"
+  type        = string
+  default     = null
+}

--- a/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
+++ b/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
@@ -9,11 +9,13 @@ variables {
       vpc_id             = "vpc-apwiefunawg"
       private_subnet_ids = ["sub1", "sub2"]
       public_subnet_ids  = ["sub3", "sub4"]
+      additional_private_subnet_ids = ["sub5", "sub6"]
     }
     "infra1" = {
       vpc_id             = "vpc-aaweoiuna9weg"
       private_subnet_ids = ["sub5", "sub6"]
       public_subnet_ids  = ["sub7", "sub8"]
+      additional_private_subnet_ids = ["sub5", "sub6"]
     }
   }
   route_table_routes = [

--- a/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
+++ b/modules/aws-vpc-tgw/tests/tgw_module.tftest.hcl
@@ -6,15 +6,15 @@ variables {
   vpc_name     = "infra1"
   vpcs = {
     "egress" = {
-      vpc_id             = "vpc-apwiefunawg"
-      private_subnet_ids = ["sub1", "sub2"]
-      public_subnet_ids  = ["sub3", "sub4"]
+      vpc_id                        = "vpc-apwiefunawg"
+      private_subnet_ids            = ["sub1", "sub2"]
+      public_subnet_ids             = ["sub3", "sub4"]
       additional_private_subnet_ids = ["sub5", "sub6"]
     }
     "infra1" = {
-      vpc_id             = "vpc-aaweoiuna9weg"
-      private_subnet_ids = ["sub5", "sub6"]
-      public_subnet_ids  = ["sub7", "sub8"]
+      vpc_id                        = "vpc-aaweoiuna9weg"
+      private_subnet_ids            = ["sub5", "sub6"]
+      public_subnet_ids             = ["sub7", "sub8"]
       additional_private_subnet_ids = ["sub5", "sub6"]
     }
   }

--- a/tests/integration.tftest.hcl
+++ b/tests/integration.tftest.hcl
@@ -15,6 +15,7 @@ variables {
   project_name           = "projecta"
   environment            = "test"
   parent_pool_cidr_block = "10.250.0.0/16"
+  ipam_scope_id          = null
   network_config = {
     vpcs = {
       "egress" = {

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -6,6 +6,7 @@ variables {
   project_name           = "projecta"
   environment            = "test"
   parent_pool_cidr_block = "10.250.0.0/16"
+  ipam_scope_id          = null
   network_config = {
     vpcs = {
       "egress" = {

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "parent_pool_cidr_block" {
   }
 }
 
+variable "ipam_scope_id" {
+  description = "Override IPAM Scope ID to use for VPC/Subnet Assignment"
+  type        = string
+  default     = null
+}
+
 variable "network_config" {
   description = "Network Configuration"
   type = object(


### PR DESCRIPTION
Allow users to submit an already existing scope id for VPC parent pool creation.  This will not attempt to create a parent IPAM instance for the account and utilize an existing pool.

Closes #2 