### PR TITLE
Allow Configuration of Internet Monitor and CloudWatch Alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,10 +458,11 @@ The following example will create:
 
 1. Support for additional named private subnets.
 
-#### Version 2.1.0
+#### Version 2.2.0
 
-1. Add observability with configuration of Internet Monitor for selected VPCs.
-2. Add support to configure SNS topics, subscriptions and alarms for Iternet Monitor.
+1. [2.1.0] Add support to configure existing IPAM scope ID.
+2. Add observability with configuration of Internet Monitor for selected VPCs.
+3. Add support to configure SNS topics, subscriptions and alarms for Iternet Monitor.
 
 ## Required Permissions
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Terraform Module to simplify the creation of complex AWS VPC Networking configur
 - [License](#license)
 
 ## Usage Example
+*More examples can be found in [Examples](https://github.com/stajkowski/terraform-aws-networking/tree/main/examples)
 ```
 locals {
   project_name           = "projecta"
@@ -21,217 +22,274 @@ locals {
   parent_pool_cidr_block = "10.0.0.0/8"
   ipam_scope_id          = null
   network_config = {
-    vpcs = {
-      "egress" = {
-        public_subnets       = 2
-        private_subnets      = 2
-        vpc_cidr_subnet_mask = 16
-        subnet_mask          = 24
-        additional_private_subnets   = {}
-        public_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 443
-            to_port     = 443
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 80
-            to_port     = 80
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
-          }
-        ]
-        private_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "infra1"
-            from_port   = 0
-            to_port     = 0
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "ipam_account_pool"
-            from_port   = 22
-            to_port     = 22
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
-          }
-        ]
-        gw_services = {
-          igw_is_enabled       = true
-          nat_gw_is_enabled    = true
-          nat_gw_type          = "public"
-          nat_gw_ha            = true
-          vpc_gateway_services = ["s3"]
-          vpc_interface_services = [
-            "ec2", "sts"
+    "test" = {
+      vpcs = {
+        "egress" = {
+          public_subnets             = 2
+          private_subnets            = 2
+          vpc_cidr_subnet_mask       = 16
+          subnet_mask                = 24
+          additional_private_subnets = {}
+          public_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 443
+              to_port     = 443
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 80
+              to_port     = 80
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
           ]
-          vpc_interface_services_scope = "private"
-        }
-        tgw_config = {
-          route_destinations = ["infra1"]
-        }
-      }
-      "infra1" = {
-        public_subnets       = 0
-        private_subnets      = 2
-        vpc_cidr_subnet_mask = 16
-        subnet_mask          = 24
-        additional_private_subnets   = {
-          "db" = {
-            subnet_count = 2
-            nacl_rules = [
-              {
-                rule_number = 10
-                egress      = false
-                action      = "allow"
-                protocol    = 6
-                cidr_block  = "infra1"
-                from_port   = 3306
-                to_port     = 3306
-              },
-              {
-                rule_number = 20
-                egress      = false
-                action      = "allow"
-                protocol    = 6
-                cidr_block  = "ipam_account_pool"
-                from_port   = 1024
-                to_port     = 65535
-              },
-              {
-                rule_number = 10
-                egress      = true
-                action      = "allow"
-                protocol    = -1
-                cidr_block  = "ipam_account_pool"
-                from_port   = 0
-                to_port     = 0
-              }
+          private_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "infra1"
+              from_port   = 0
+              to_port     = 0
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "ipam_account_pool"
+              from_port   = 22
+              to_port     = 22
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
+          ]
+          gw_services = {
+            igw_is_enabled       = true
+            nat_gw_is_enabled    = true
+            nat_gw_type          = "public"
+            nat_gw_ha            = true
+            vpc_gateway_services = ["s3"]
+            vpc_interface_services = [
+              "ec2", "sts"
             ]
+            vpc_interface_services_scope = "private"
+          }
+          tgw_config = {
+            route_destinations = ["infra1"]
           }
         }
-        public_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 443
-            to_port     = 443
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 80
-            to_port     = 80
-          },
-          {
-            rule_number = 30
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 1024
-            to_port     = 65535
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
+        "infra1" = {
+          public_subnets       = 0
+          private_subnets      = 2
+          vpc_cidr_subnet_mask = 16
+          subnet_mask          = 24
+          additional_private_subnets = {
+            "db" = {
+              subnet_count = 2
+              nacl_rules = [
+                {
+                  rule_number = 10
+                  egress      = false
+                  action      = "allow"
+                  protocol    = 6
+                  cidr_block  = "infra1"
+                  from_port   = 3306
+                  to_port     = 3306
+                },
+                {
+                  rule_number = 20
+                  egress      = false
+                  action      = "allow"
+                  protocol    = 6
+                  cidr_block  = "ipam_account_pool"
+                  from_port   = 1024
+                  to_port     = 65535
+                },
+                {
+                  rule_number = 10
+                  egress      = true
+                  action      = "allow"
+                  protocol    = -1
+                  cidr_block  = "ipam_account_pool"
+                  from_port   = 0
+                  to_port     = 0
+                }
+              ]
+            }
           }
-        ]
-        private_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 1024
-            to_port     = 65535
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "egress"
-            from_port   = 22
-            to_port     = 22
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
-          }
-        ]
-        gw_services = {
-          igw_is_enabled       = false
-          nat_gw_is_enabled    = false
-          nat_gw_type          = "private"
-          nat_gw_ha            = false
-          vpc_gateway_services = []
-          vpc_interface_services = [
-            "ec2", "sts"
+          public_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 443
+              to_port     = 443
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 80
+              to_port     = 80
+            },
+            {
+              rule_number = 30
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 1024
+              to_port     = 65535
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
           ]
-          vpc_interface_services_scope = "private"
-        }
-        tgw_config = {
-          route_destinations = ["0.0.0.0/0"]
+          private_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 1024
+              to_port     = 65535
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "egress"
+              from_port   = 22
+              to_port     = 22
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
+          ]
+          gw_services = {
+            igw_is_enabled       = false
+            nat_gw_is_enabled    = false
+            nat_gw_type          = "private"
+            nat_gw_ha            = false
+            vpc_gateway_services = []
+            vpc_interface_services = [
+              "ec2", "sts"
+            ]
+            vpc_interface_services_scope = "private"
+          }
+          tgw_config = {
+            route_destinations = ["0.0.0.0/0"]
+          }
         }
       }
-    }
-    transit_gw = {
-      tgw_is_enabled = true
-      tgw_vpc_attach = ["infra1", "egress"]
-      tgw_routes = [
-        {
-          "destination" = "0.0.0.0/0"
-          "vpc_attachment"  = "egress"
+      transit_gw = {
+        tgw_is_enabled = true
+        tgw_vpc_attach = ["infra1", "egress"]
+        tgw_routes = [
+          {
+            "destination"    = "0.0.0.0/0"
+            "vpc_attachment" = "egress"
+          }
+        ]
+      }
+      internet_monitor = {
+        is_enabled                    = true
+        monitor_vpcs                  = ["egress"]
+        traffic_percentage_to_monitor = 50
+        max_city_networks_to_monitor  = 100
+        availability_threshold        = 96
+        performance_threshold         = 96
+        status                        = "ACTIVE"
+        alarm_config = {
+          sns_topics = {
+            "egress-alarms" = {}
+          }
+          sns_subscriptions = [
+            {
+              topic    = "egress-alarms"
+              protocol = "email"
+              endpoint = "infra-alerts@example.com"
+            }
+          ]
+          alarms = {
+            "egress-availability-score" = {
+              description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+              comparison          = "LessThanThreshold"
+              metric_name         = "AvailabilityScore"
+              namespace           = "AWS/InternetMonitor"
+              statistic           = "Average"
+              period              = 300
+              threshold           = 96
+              evaluation_periods  = 2
+              datapoints_to_alarm = 2
+              actions_enabled     = true
+              treat_missing_data  = "missing"
+              alarm_actions = [
+                "egress-alarms"
+              ]
+            }
+            "egress-performance-score" = {
+              description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+              comparison          = "LessThanThreshold"
+              metric_name         = "PerformanceScore"
+              namespace           = "AWS/InternetMonitor"
+              statistic           = "Average"
+              period              = 300
+              threshold           = 96
+              evaluation_periods  = 2
+              datapoints_to_alarm = 2
+              actions_enabled     = true
+              treat_missing_data  = "missing"
+              alarm_actions = [
+                "egress-alarms"
+              ]
+            }
+          }
         }
-      ]
+      }
     }
   }
 }
@@ -241,13 +299,13 @@ provider "aws" {
 }
 
 module "aws-networking" {
-  source  = "stajkowski/networking/aws"
-  version = "2.1.0"
-  project_name = local.project_name
-  environment = local.environment
+  source                 = "stajkowski/networking/aws"
+  version                = "2.1.0"
+  project_name           = local.project_name
+  environment            = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
   ipam_scope_id          = local.ipam_scope_id
-  network_config = local.network_config
+  network_config         = local.network_config[local.environment]
 }
 ```
 The following example will create:
@@ -327,9 +385,9 @@ The following example will create:
 | environment | Current environment stage to configure.  This value is only utilized in naming resources and applying tags. | `string`
 | parent_pool_cidr_block | CIDR block for Environment Parent VPC Pools, i.e. 10.0.0.0/8. | `string`
 | ipam_scope_id | Existing IPAM scope ID for Environment VPC Parent Pool Creation.  Use standard ARN format for Scope ID. i.e. `ipam-scope-04dd36eca6021f93e`.  | `string`
-| network_config | Network configuration values utilized to standup VPC resources. | `object()`
+| network_config | Network configuration values utilized to standup VPC resources. `object({vpcs={},transit_gw={},internet_monitor={}})` | `object()`
 
-#### Network Configuration Inputs
+#### Network Configuration Inputs (VPC)
 | Name      | Description   | Type    |
 |-----------|-----------|-----------|
 | vpcs.public_subnets | Number of public subnets to create in the VPC.  This is required to be > 0 if an Internet Gateway is configured for the VPC. | `number`
@@ -349,15 +407,23 @@ The following example will create:
 | vpcs.public_subnet_nacl_rules | This will iterate over the configured NACL rules and assign them to the public subnet ids. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR.  Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
 | vpcs.private_subnet_nacl_rules | This will iterate over the configured NACL rules and assign them to the private subnet ids. This is direct configuration of NACL Rules in AWS with support for dynamic names of VPCs in the cidr_block within aws-networking module.  It is possible to supply a standard CIDR  for `cidr_block` such as "10.0.0.0/8" or "0.0.0.0/0", but alternatively you can pass the key value under "vpcs", which is the name of your VPC.  aws-networking module will then replace the VPC name with the assigned CIDR. Additionally, `ipam_account_pool` can be set for the `cidr_block` to replace this value with the configured account level pool or parent pool. | `list(object())`
 | vpcs.tgw_config.route_destinations | This will configure routes within the VPC Route Tables to the Transit Gateway. The configured value can be static, such as "0.0.0.0/0", or dynamic, similar to the NACL rules.  When using dynamic, utilize the VPC name you assigned to the VPC under "vpcs".  aws-networking module will replace the VPC name with the assigned CIDR. | `list(string)`
+
+#### Network Configuration Inputs (Transit Gateway)
+| Name      | Description   | Type    |
+|-----------|-----------|-----------|
 | transit_gw.tgw_is_enabled | Boolean value to indicate that aws-networking should create a Transit Gateway. | `bool`
 | transit_gw.tgw_vpc_attach | List of named VPCs to attach to the Transit Gateway. | `list(string)`
 | transit_gw.tgw_routes | List of routes to add into the Transit Gateway. | `list(object())`
 | transit_gw.tgw_routes.*.destination | Destination route, such as `0.0.0.0/0` or a VPC name like `egress`. | `string`
 | transit_gw.tgw_routes.*.vpc_attachment | Name of the VPC that is attached to Transit Gateway in `transit_gw.tgw_vpc_attach`. This will point the destination toward the VPC named in this parameter. | `string`
 
-## Major Revision Updates
+#### Network Configuration Inputs (Iternet Monitor)
+| Name      | Description   | Type    |
+|-----------|-----------|-----------|
 
-#### Version 1.0 (Initial Release)
+## Revision Updates
+
+#### Version 1.0.0 (Initial Release)
 
 1. Support for any number of VPCs.
 2. Creation of a dynamic set of public and private subnets.
@@ -374,9 +440,14 @@ The following example will create:
 13. Transit Gateway with VPC assignment.
 14. Transit Gateway route updates for every route table in the assigned VPC.
 
-#### Version 2.0
+#### Version 2.0.0
 
 1. Support for additional named private subnets.
+
+#### Version 2.1.0
+
+1. Add observability with configuration of Internet Monitor for selected VPCs.
+2. Add support to configure SNS topics, subscriptions and alarms for Iternet Monitor.
 
 ## Required Permissions
 ```
@@ -408,6 +479,29 @@ The following example will create:
 				"ec2:DeleteIpamPool",
 				"ec2:GetIpamPoolAllocations",
 				"iam:CreateServiceLinkedRole"
+			],
+			"Resource": "*"
+		},
+		{
+			"Sid": "InternetMonitor",
+			"Effect": "Allow",
+			"Action": [
+				"internetmonitor:*",
+				"sns:CreateTopic",
+				"sns:DeleteTopic",
+				"sns:GetTopicAttributes",
+				"sns:ListSubscriptionsByTopic",
+				"sns:ListTagsForResource",
+				"sns:SetTopicAttributes",
+				"sns:Subscribe",
+				"sns:Unsubscribe",
+				"cloudwatch:DeleteAlarms",
+				"cloudwatch:DescribeAlarms",
+				"cloudwatch:DisableAlarmActions",
+				"cloudwatch:EnableAlarmActions",
+				"cloudwatch:PutMetricAlarm",
+				"cloudwatch:TagResource",
+				"cloudwatch:UntagResource"
 			],
 			"Resource": "*"
 		},
@@ -471,7 +565,6 @@ The following example will create:
 				"ec2:DeleteVpc",
 				"ec2:DeleteVpcEndpoints",
 				"ec2:DeleteVpcEndpointServiceConfigurations",
-				"ec2:DeleteDhcpOptions",
 				"ec2:DescribeAccountAttributes",
 				"ec2:DescribeAddresses",
 				"ec2:DescribeAvailabilityZones",
@@ -523,7 +616,8 @@ The following example will create:
 				"ec2:RevokeSecurityGroupEgress",
 				"ec2:SearchTransitGatewayRoutes",
 				"ec2:UnassignIpv6Addresses",
-				"ec2:UnassignPrivateIpAddresses"
+				"ec2:UnassignPrivateIpAddresses",
+				"ec2:DeleteDhcpOptions"
 			],
 			"Resource": "*"
 		}

--- a/README.md
+++ b/README.md
@@ -326,6 +326,9 @@ The following example will create:
 12. Route destination "0.0.0.0/0" is added to the private route tables in "infra1" VPC.
 13. Route destination "infra1" (auto substituted for infra 1 CIDR) is added to public/private route tables in "egress" VPC.
 14. A default security group that can be used per VPC that allows parent IPAM pool CIDR of "10.0.0.0/8"
+15. Internet Monitor enabled and monitoring egress VPC.
+16. SNS Topic for Internet Monitor Alerts and 1 subscription with email as the protocol.
+17. 2 CloudWatch alarms for Availability and Performances score utilizing the SNS topic for alerts.
 
 *NOTE*: Size of each VPC CIDR and subnet mask can be controlled through the configuration "vpc_cidr_subnet_mask" and "subnet_mask"
 
@@ -420,6 +423,17 @@ The following example will create:
 #### Network Configuration Inputs (Iternet Monitor)
 | Name      | Description   | Type    |
 |-----------|-----------|-----------|
+| internet_monitor.is_enabled | Boolean value to indicate that aws-networking should enable Internet Monitor. | `bool`
+| internet_monitor.monitor_vpcs | List of named VPCs to enable Internet Monitor. | `list(string)`
+| internet_monitor.traffic_percentage_to_monitor | https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/IMTrafficPercentage.html | `number`
+| internet_monitor.max_city_networks_to_monitor | https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/IMCityNetworksMaximum.html | `number`
+| internet_monitor.availability_threshold | https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-IM-overview.html#IMUpdateThresholdFromOverview | `number`
+| internet_monitor.performance_threshold | https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-IM-overview.html#IMUpdateThresholdFromOverview | `number`
+| internet_monitor.status | (`ACTIVE`,`INACTIVE`) Set Internet Monitor status. | `number`
+| internet_monitor.alarm_config | Iternet Monitor alarm configuration for SNS Topics, Subscriptions, and CloudWatch Alarms. | `object()`
+| internet_monitor.alarm_config.sns_topics | Named SNS Topics created based on key value.  Object value not used and reserved for future use. | `map()`
+| internet_monitor.alarm_config.sns_subscriptions | List of objects containing the SNS subscriptions: topic, protocol, and endpoint. https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html | `object()`
+| internet_monitor.alarm_config.alarms | Map of alarms to create, please refer to CloudWatch documentation on exact settings to support your use case: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html | `map(object())`
 
 ## Revision Updates
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -216,6 +216,15 @@ locals {
         }
       ]
     }
+    internet_monitor = {
+      is_enabled = true
+      monitor_vpcs = ["egress"]
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor = 100
+      availability_threshold = 96
+      performance_threshold = 96
+      status = "ACTIVE"
+    }
   }
 }
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -4,226 +4,274 @@ locals {
   parent_pool_cidr_block = "10.0.0.0/8"
   ipam_scope_id          = null
   network_config = {
-    vpcs = {
-      "egress" = {
-        public_subnets             = 2
-        private_subnets            = 2
-        vpc_cidr_subnet_mask       = 16
-        subnet_mask                = 24
-        additional_private_subnets = {}
-        public_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 443
-            to_port     = 443
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 80
-            to_port     = 80
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
-          }
-        ]
-        private_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "infra1"
-            from_port   = 0
-            to_port     = 0
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "ipam_account_pool"
-            from_port   = 22
-            to_port     = 22
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
-          }
-        ]
-        gw_services = {
-          igw_is_enabled       = true
-          nat_gw_is_enabled    = true
-          nat_gw_type          = "public"
-          nat_gw_ha            = true
-          vpc_gateway_services = ["s3"]
-          vpc_interface_services = [
-            "ec2", "sts"
+    "test" = {
+      vpcs = {
+        "egress" = {
+          public_subnets             = 2
+          private_subnets            = 2
+          vpc_cidr_subnet_mask       = 16
+          subnet_mask                = 24
+          additional_private_subnets = {}
+          public_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 443
+              to_port     = 443
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 80
+              to_port     = 80
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
           ]
-          vpc_interface_services_scope = "private"
-        }
-        tgw_config = {
-          route_destinations = ["infra1"]
-        }
-      }
-      "infra1" = {
-        public_subnets       = 0
-        private_subnets      = 2
-        vpc_cidr_subnet_mask = 16
-        subnet_mask          = 24
-        additional_private_subnets = {
-          "db" = {
-            subnet_count = 2
-            nacl_rules = [
-              {
-                rule_number = 10
-                egress      = false
-                action      = "allow"
-                protocol    = 6
-                cidr_block  = "infra1"
-                from_port   = 3306
-                to_port     = 3306
-              },
-              {
-                rule_number = 20
-                egress      = false
-                action      = "allow"
-                protocol    = 6
-                cidr_block  = "ipam_account_pool"
-                from_port   = 1024
-                to_port     = 65535
-              },
-              {
-                rule_number = 10
-                egress      = true
-                action      = "allow"
-                protocol    = -1
-                cidr_block  = "ipam_account_pool"
-                from_port   = 0
-                to_port     = 0
-              }
+          private_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "infra1"
+              from_port   = 0
+              to_port     = 0
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "ipam_account_pool"
+              from_port   = 22
+              to_port     = 22
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
+          ]
+          gw_services = {
+            igw_is_enabled       = true
+            nat_gw_is_enabled    = true
+            nat_gw_type          = "public"
+            nat_gw_ha            = true
+            vpc_gateway_services = ["s3"]
+            vpc_interface_services = [
+              "ec2", "sts"
             ]
+            vpc_interface_services_scope = "private"
+          }
+          tgw_config = {
+            route_destinations = ["infra1"]
           }
         }
-        public_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 443
-            to_port     = 443
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 80
-            to_port     = 80
-          },
-          {
-            rule_number = 30
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 1024
-            to_port     = 65535
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
+        "infra1" = {
+          public_subnets       = 0
+          private_subnets      = 2
+          vpc_cidr_subnet_mask = 16
+          subnet_mask          = 24
+          additional_private_subnets = {
+            "db" = {
+              subnet_count = 2
+              nacl_rules = [
+                {
+                  rule_number = 10
+                  egress      = false
+                  action      = "allow"
+                  protocol    = 6
+                  cidr_block  = "infra1"
+                  from_port   = 3306
+                  to_port     = 3306
+                },
+                {
+                  rule_number = 20
+                  egress      = false
+                  action      = "allow"
+                  protocol    = 6
+                  cidr_block  = "ipam_account_pool"
+                  from_port   = 1024
+                  to_port     = 65535
+                },
+                {
+                  rule_number = 10
+                  egress      = true
+                  action      = "allow"
+                  protocol    = -1
+                  cidr_block  = "ipam_account_pool"
+                  from_port   = 0
+                  to_port     = 0
+                }
+              ]
+            }
           }
-        ]
-        private_subnet_nacl_rules = [
-          {
-            rule_number = 10
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 1024
-            to_port     = 65535
-          },
-          {
-            rule_number = 20
-            egress      = false
-            action      = "allow"
-            protocol    = 6
-            cidr_block  = "egress"
-            from_port   = 22
-            to_port     = 22
-          },
-          {
-            rule_number = 10
-            egress      = true
-            action      = "allow"
-            protocol    = -1
-            cidr_block  = "0.0.0.0/0"
-            from_port   = 0
-            to_port     = 0
-          }
-        ]
-        gw_services = {
-          igw_is_enabled       = false
-          nat_gw_is_enabled    = false
-          nat_gw_type          = "private"
-          nat_gw_ha            = false
-          vpc_gateway_services = []
-          vpc_interface_services = [
-            "ec2", "sts"
+          public_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 443
+              to_port     = 443
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 80
+              to_port     = 80
+            },
+            {
+              rule_number = 30
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 1024
+              to_port     = 65535
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
           ]
-          vpc_interface_services_scope = "private"
-        }
-        tgw_config = {
-          route_destinations = ["0.0.0.0/0"]
+          private_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 1024
+              to_port     = 65535
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "egress"
+              from_port   = 22
+              to_port     = 22
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
+          ]
+          gw_services = {
+            igw_is_enabled       = false
+            nat_gw_is_enabled    = false
+            nat_gw_type          = "private"
+            nat_gw_ha            = false
+            vpc_gateway_services = []
+            vpc_interface_services = [
+              "ec2", "sts"
+            ]
+            vpc_interface_services_scope = "private"
+          }
+          tgw_config = {
+            route_destinations = ["0.0.0.0/0"]
+          }
         }
       }
-    }
-    transit_gw = {
-      tgw_is_enabled = true
-      tgw_vpc_attach = ["infra1", "egress"]
-      tgw_routes = [
-        {
-          "destination"    = "0.0.0.0/0"
-          "vpc_attachment" = "egress"
+      transit_gw = {
+        tgw_is_enabled = true
+        tgw_vpc_attach = ["infra1", "egress"]
+        tgw_routes = [
+          {
+            "destination"    = "0.0.0.0/0"
+            "vpc_attachment" = "egress"
+          }
+        ]
+      }
+      internet_monitor = {
+        is_enabled = true
+        monitor_vpcs = ["egress"]
+        traffic_percentage_to_monitor = 50
+        max_city_networks_to_monitor = 100
+        availability_threshold = 96
+        performance_threshold = 96
+        status = "ACTIVE"
+        alarm_config = {
+          sns_topics = {
+            "egress-alarms" = {}
+          }
+          sns_subscriptions = [
+            {
+              topic    = "egress-alarms"
+              protocol = "email"
+              endpoint = "infra-alerts@example.com"
+            }
+          ]
+          alarms = {
+            "egress-availability-score" = {
+              description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+              comparison          = "LessThanThreshold"
+              metric_name         = "AvailabilityScore"
+              namespace           = "AWS/InternetMonitor"
+              statistic           = "Average"
+              period              = 300
+              threshold           = 96
+              evaluation_periods  = 2
+              datapoints_to_alarm = 2
+              actions_enabled     = true
+              treat_missing_data  = "missing"
+              alarm_actions = [
+                "egress-alarms"
+              ]
+            }
+            "egress-performance-score" = {
+              description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+              comparison          = "LessThanThreshold"
+              metric_name         = "PerformanceScore"
+              namespace           = "AWS/InternetMonitor"
+              statistic           = "Average"
+              period              = 300
+              threshold           = 96
+              evaluation_periods  = 2
+              datapoints_to_alarm = 2
+              actions_enabled     = true
+              treat_missing_data  = "missing"
+              alarm_actions = [
+                "egress-alarms"
+              ]
+            }
+          }
         }
-      ]
-    }
-    internet_monitor = {
-      is_enabled = true
-      monitor_vpcs = ["egress"]
-      traffic_percentage_to_monitor = 50
-      max_city_networks_to_monitor = 100
-      availability_threshold = 96
-      performance_threshold = 96
-      status = "ACTIVE"
+      }
     }
   }
 }
@@ -238,5 +286,5 @@ module "aws-networking" {
   environment            = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block
   ipam_scope_id          = local.ipam_scope_id
-  network_config         = local.network_config
+  network_config         = local.network_config[local.environment]
 }

--- a/examples/single_vpc/main.tf
+++ b/examples/single_vpc/main.tf
@@ -1,0 +1,163 @@
+locals {
+  project_name           = "projecta"
+  environment            = "test"
+  parent_pool_cidr_block = "10.0.0.0/8"
+  ipam_scope_id          = null
+  network_config = {
+    "test" = {
+      vpcs = {
+        "webapp" = {
+          public_subnets             = 2
+          private_subnets            = 2
+          vpc_cidr_subnet_mask       = 16
+          subnet_mask                = 24
+          additional_private_subnets = {
+            "db" = {
+              subnet_count = 2
+              nacl_rules = [
+                {
+                  rule_number = 10
+                  egress      = false
+                  action      = "allow"
+                  protocol    = 6
+                  cidr_block  = "webapp"
+                  from_port   = 3306
+                  to_port     = 3306
+                },
+                { # Rule aonly allows return traffic from Webapp VPC
+                  rule_number = 20
+                  egress      = false
+                  action      = "allow"
+                  protocol    = 6
+                  cidr_block  = "webapp"
+                  from_port   = 1024
+                  to_port     = 65535
+                },
+                {
+                  rule_number = 10
+                  egress      = true
+                  action      = "allow"
+                  protocol    = -1
+                  cidr_block  = "webapp"
+                  from_port   = 0
+                  to_port     = 0
+                }
+              ]
+            }
+          }
+          public_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 443
+              to_port     = 443
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 80
+              to_port     = 80
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
+          ]
+          private_subnet_nacl_rules = [
+            {
+              rule_number = 10
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "webapp"
+              from_port   = 443
+              to_port     = 443
+            },
+            {
+              rule_number = 20
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "ipam_account_pool"
+              from_port   = 22
+              to_port     = 22
+            },
+            { # Rule allows NAT GW return traffic
+              rule_number = 30
+              egress      = false
+              action      = "allow"
+              protocol    = 6
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 1024
+              to_port     = 65535
+            },
+            {
+              rule_number = 10
+              egress      = true
+              action      = "allow"
+              protocol    = -1
+              cidr_block  = "0.0.0.0/0"
+              from_port   = 0
+              to_port     = 0
+            }
+          ]
+          gw_services = {
+            igw_is_enabled       = true
+            nat_gw_is_enabled    = true
+            nat_gw_type          = "public"
+            nat_gw_ha            = false
+            vpc_gateway_services = []
+            vpc_interface_services = []
+            vpc_interface_services_scope = "private"
+          }
+          tgw_config = {
+            route_destinations = []
+          }
+        }
+      }
+      transit_gw = {
+        tgw_is_enabled = false
+        tgw_vpc_attach = []
+        tgw_routes = []
+      }
+      internet_monitor = {
+        is_enabled                    = false
+        monitor_vpcs                  = []
+        traffic_percentage_to_monitor = 50
+        max_city_networks_to_monitor  = 100
+        availability_threshold        = 96
+        performance_threshold         = 96
+        status                        = "ACTIVE"
+        alarm_config = {
+          sns_topics = {}
+          sns_subscriptions = []
+          alarms = {}
+        }
+      }
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws-networking" {
+  source                 = "../../"
+  project_name           = local.project_name
+  environment            = local.environment
+  parent_pool_cidr_block = local.parent_pool_cidr_block
+  ipam_scope_id          = local.ipam_scope_id
+  network_config         = local.network_config[local.environment]
+}

--- a/examples/single_vpc/main.tf
+++ b/examples/single_vpc/main.tf
@@ -7,10 +7,10 @@ locals {
     "test" = {
       vpcs = {
         "webapp" = {
-          public_subnets             = 2
-          private_subnets            = 2
-          vpc_cidr_subnet_mask       = 16
-          subnet_mask                = 24
+          public_subnets       = 2
+          private_subnets      = 2
+          vpc_cidr_subnet_mask = 16
+          subnet_mask          = 24
           additional_private_subnets = {
             "db" = {
               subnet_count = 2
@@ -113,12 +113,12 @@ locals {
             }
           ]
           gw_services = {
-            igw_is_enabled       = true
-            nat_gw_is_enabled    = true
-            nat_gw_type          = "public"
-            nat_gw_ha            = false
-            vpc_gateway_services = []
-            vpc_interface_services = []
+            igw_is_enabled               = true
+            nat_gw_is_enabled            = true
+            nat_gw_type                  = "public"
+            nat_gw_ha                    = false
+            vpc_gateway_services         = []
+            vpc_interface_services       = []
             vpc_interface_services_scope = "private"
           }
           tgw_config = {
@@ -129,7 +129,7 @@ locals {
       transit_gw = {
         tgw_is_enabled = false
         tgw_vpc_attach = []
-        tgw_routes = []
+        tgw_routes     = []
       }
       internet_monitor = {
         is_enabled                    = true

--- a/examples/single_vpc/main.tf
+++ b/examples/single_vpc/main.tf
@@ -132,17 +132,58 @@ locals {
         tgw_routes = []
       }
       internet_monitor = {
-        is_enabled                    = false
-        monitor_vpcs                  = []
+        is_enabled                    = true
+        monitor_vpcs                  = ["webapp"]
         traffic_percentage_to_monitor = 50
         max_city_networks_to_monitor  = 100
         availability_threshold        = 96
         performance_threshold         = 96
         status                        = "ACTIVE"
         alarm_config = {
-          sns_topics = {}
-          sns_subscriptions = []
-          alarms = {}
+          sns_topics = {
+            "webapp-alarms" = {}
+          }
+          sns_subscriptions = [
+            {
+              topic    = "webapp-alarms"
+              protocol = "email"
+              endpoint = "infra-alerts@example.com"
+            }
+          ]
+          alarms = {
+            "egress-availability-score" = {
+              description         = "AWS Iternet Monitor Webapp availability score less than 96 for 5m."
+              comparison          = "LessThanThreshold"
+              metric_name         = "AvailabilityScore"
+              namespace           = "AWS/InternetMonitor"
+              statistic           = "Average"
+              period              = 300
+              threshold           = 96
+              evaluation_periods  = 2
+              datapoints_to_alarm = 2
+              actions_enabled     = true
+              treat_missing_data  = "missing"
+              alarm_actions = [
+                "webapp-alarms"
+              ]
+            }
+            "egress-performance-score" = {
+              description         = "AWS Iternet Monitor Webapp performance score less than 96 for 5m."
+              comparison          = "LessThanThreshold"
+              metric_name         = "PerformanceScore"
+              namespace           = "AWS/InternetMonitor"
+              statistic           = "Average"
+              period              = 300
+              threshold           = 96
+              evaluation_periods  = 2
+              datapoints_to_alarm = 2
+              actions_enabled     = true
+              treat_missing_data  = "missing"
+              alarm_actions = [
+                "webapp-alarms"
+              ]
+            }
+          }
         }
       }
     }

--- a/examples/transit_gateway/main.tf
+++ b/examples/transit_gateway/main.tf
@@ -218,13 +218,13 @@ locals {
         ]
       }
       internet_monitor = {
-        is_enabled = true
-        monitor_vpcs = ["egress"]
+        is_enabled                    = true
+        monitor_vpcs                  = ["egress"]
         traffic_percentage_to_monitor = 50
-        max_city_networks_to_monitor = 100
-        availability_threshold = 96
-        performance_threshold = 96
-        status = "ACTIVE"
+        max_city_networks_to_monitor  = 100
+        availability_threshold        = 96
+        performance_threshold         = 96
+        status                        = "ACTIVE"
         alarm_config = {
           sns_topics = {
             "egress-alarms" = {}
@@ -281,7 +281,7 @@ provider "aws" {
 }
 
 module "aws-networking" {
-  source                 = "../"
+  source                 = "../../"
   project_name           = local.project_name
   environment            = local.environment
   parent_pool_cidr_block = local.parent_pool_cidr_block

--- a/main.tf
+++ b/main.tf
@@ -186,70 +186,12 @@ module "aws-vpc-tgw" {
   tgw_vpc_attach = var.network_config.transit_gw.tgw_vpc_attach
 }
 
-
-
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
-
-locals {
-  alarm_config = var.network_config.internet_monitor.is_enabled ? var.network_config.internet_monitor.alarm_config : {
-    sns_topics        = {}
-    sns_subscriptions = []
-    alarms            = {}
-  }
-}
-
 # Create Internet Monitor
-resource "aws_internetmonitor_monitor" "internet_monitor" {
-  count        = var.network_config.internet_monitor.is_enabled ? 1 : 0
-  depends_on   = [module.aws-vpc]
-  monitor_name = "${var.project_name}-${var.environment}-internet-monitor"
-  resources = toset([
-    for vpc in var.network_config.internet_monitor.monitor_vpcs : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vpc/${module.aws-vpc[vpc].vpc_id}"
-  ])
-  max_city_networks_to_monitor  = var.network_config.internet_monitor.max_city_networks_to_monitor
-  traffic_percentage_to_monitor = var.network_config.internet_monitor.traffic_percentage_to_monitor
-  health_events_config {
-    availability_score_threshold = var.network_config.internet_monitor.availability_threshold
-    performance_score_threshold  = var.network_config.internet_monitor.performance_threshold
-  }
-  status = var.network_config.internet_monitor.status
-}
-
-# Create SNS Topics
-resource "aws_sns_topic" "sns_topics" {
-  for_each = local.alarm_config.sns_topics
-  name     = "${var.project_name}-${var.environment}-${each.key}"
-}
-
-# Create SNS Subscriptions
-resource "aws_sns_topic_subscription" "sns_subscriptions" {
-  depends_on = [aws_sns_topic.sns_topics]
-  count      = length(local.alarm_config.sns_subscriptions)
-  topic_arn  = aws_sns_topic.sns_topics[local.alarm_config.sns_subscriptions[count.index].topic].arn
-  protocol   = local.alarm_config.sns_subscriptions[count.index].protocol
-  endpoint   = local.alarm_config.sns_subscriptions[count.index].endpoint
-}
-
-resource "aws_cloudwatch_metric_alarm" "internet_monitor_alarms" {
-  depends_on          = [aws_sns_topic.sns_topics, aws_internetmonitor_monitor.internet_monitor]
-  for_each            = local.alarm_config.alarms
-  alarm_name          = "${var.project_name}-${var.environment}-${each.key}"
-  alarm_description   = each.value.description
-  comparison_operator = each.value.comparison
-  evaluation_periods  = each.value.evaluation_periods
-  datapoints_to_alarm = each.value.datapoints_to_alarm
-  metric_name         = each.value.metric_name
-  namespace           = each.value.namespace
-  period              = each.value.period
-  statistic           = each.value.statistic
-  threshold           = each.value.threshold
-  treat_missing_data  = each.value.treat_missing_data
-
-  dimensions = {
-    "MonitorName" : aws_internetmonitor_monitor.internet_monitor[0].monitor_name
-    "MeasurementSource" : "AWS"
-  }
-  actions_enabled = each.value.actions_enabled
-  alarm_actions   = [for action in each.value.alarm_actions : aws_sns_topic.sns_topics[action].arn]
+module "aws-cw-internet-monitor" {
+  source                  = "./modules/aws-cw-internet-monitor"
+  depends_on              = [module.aws-vpc]
+  project_name            = var.project_name
+  environment             = var.environment
+  internet_monitor_config = var.network_config.internet_monitor
+  aws_vpc                 = module.aws-vpc
 }

--- a/main.tf
+++ b/main.tf
@@ -186,8 +186,18 @@ module "aws-vpc-tgw" {
   tgw_vpc_attach = var.network_config.transit_gw.tgw_vpc_attach
 }
 
+
+
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+
+locals {
+  alarm_config = var.network_config.internet_monitor.is_enabled ? var.network_config.internet_monitor.alarm_config : {
+    sns_topics = {}
+    sns_subscriptions = []
+    alarms = {}
+  }
+}
 
 # Create Internet Monitor
 resource "aws_internetmonitor_monitor" "internet_monitor" {
@@ -204,4 +214,42 @@ resource "aws_internetmonitor_monitor" "internet_monitor" {
     performance_score_threshold  = var.network_config.internet_monitor.performance_threshold
   }
   status = var.network_config.internet_monitor.status
+}
+
+# Create SNS Topics
+resource "aws_sns_topic" "sns_topics" {
+  for_each   = local.alarm_config.sns_topics
+  name       = "${var.project_name}-${var.environment}-${each.key}"
+}
+
+# Create SNS Subscriptions
+resource "aws_sns_topic_subscription" "sns_subscriptions" {
+  depends_on = [aws_sns_topic.sns_topics]
+  count      = length(local.alarm_config.sns_subscriptions)
+  topic_arn  = aws_sns_topic.sns_topics[local.alarm_config.sns_subscriptions[count.index].topic].arn
+  protocol   = local.alarm_config.sns_subscriptions[count.index].protocol
+  endpoint   = local.alarm_config.sns_subscriptions[count.index].endpoint
+}
+
+resource "aws_cloudwatch_metric_alarm" "internet_monitor_alarms" {
+  depends_on          = [aws_sns_topic.sns_topics, aws_internetmonitor_monitor.internet_monitor]
+  for_each            = local.alarm_config.alarms
+  alarm_name          = "${var.project_name}-${var.environment}-${each.key}"
+  alarm_description   = each.value.description
+  comparison_operator = each.value.comparison
+  evaluation_periods  = each.value.evaluation_periods
+  datapoints_to_alarm = each.value.datapoints_to_alarm
+  metric_name         = each.value.metric_name
+  namespace           = each.value.namespace
+  period              = each.value.period
+  statistic           = each.value.statistic
+  threshold           = each.value.threshold
+  treat_missing_data  = each.value.treat_missing_data 
+
+  dimensions = {
+    "MonitorName" : aws_internetmonitor_monitor.internet_monitor[0].monitor_name
+    "MeasurementSource": "AWS"
+  }
+  actions_enabled = each.value.actions_enabled
+  alarm_actions   = [for action in each.value.alarm_actions : aws_sns_topic.sns_topics[action].arn]
 }

--- a/modules/aws-cw-internet-monitor/main.tf
+++ b/modules/aws-cw-internet-monitor/main.tf
@@ -1,0 +1,84 @@
+# ------------------------------------------------------------------------------
+# AWS CW INTERNET MONITOR MODULE
+#
+# 1. Create Internet Monitor
+# 2. Create SNS Topics
+# 3. Create SNS Subscriptions
+# 4. Create CloudWatch Alarms
+#
+# ------------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  alarm_config = var.internet_monitor_config.is_enabled ? var.internet_monitor_config.alarm_config : {
+    sns_topics        = {}
+    sns_subscriptions = []
+    alarms            = {}
+  }
+}
+
+# Create Internet Monitor
+resource "aws_internetmonitor_monitor" "internet_monitor" {
+  count        = var.internet_monitor_config.is_enabled ? 1 : 0
+  monitor_name = "${var.project_name}-${var.environment}-internet-monitor"
+  resources = toset([
+    for vpc in var.internet_monitor_config.monitor_vpcs : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vpc/${var.aws_vpc[vpc].vpc_id}"
+  ])
+  max_city_networks_to_monitor  = var.internet_monitor_config.max_city_networks_to_monitor
+  traffic_percentage_to_monitor = var.internet_monitor_config.traffic_percentage_to_monitor
+  health_events_config {
+    availability_score_threshold = var.internet_monitor_config.availability_threshold
+    performance_score_threshold  = var.internet_monitor_config.performance_threshold
+  }
+  status = var.internet_monitor_config.status
+}
+
+# Create SNS Topics
+resource "aws_sns_topic" "sns_topics" {
+  for_each = local.alarm_config.sns_topics
+  name     = "${var.project_name}-${var.environment}-${each.key}"
+}
+
+# Create SNS Subscriptions
+resource "aws_sns_topic_subscription" "sns_subscriptions" {
+  depends_on = [aws_sns_topic.sns_topics]
+  count      = length(local.alarm_config.sns_subscriptions)
+  topic_arn  = aws_sns_topic.sns_topics[local.alarm_config.sns_subscriptions[count.index].topic].arn
+  protocol   = local.alarm_config.sns_subscriptions[count.index].protocol
+  endpoint   = local.alarm_config.sns_subscriptions[count.index].endpoint
+}
+
+# Create CloudWatch Alarms
+resource "aws_cloudwatch_metric_alarm" "internet_monitor_alarms" {
+  depends_on          = [aws_sns_topic.sns_topics, aws_internetmonitor_monitor.internet_monitor]
+  for_each            = local.alarm_config.alarms
+  alarm_name          = "${var.project_name}-${var.environment}-${each.key}"
+  alarm_description   = each.value.description
+  comparison_operator = each.value.comparison
+  evaluation_periods  = each.value.evaluation_periods
+  datapoints_to_alarm = each.value.datapoints_to_alarm
+  metric_name         = each.value.metric_name
+  namespace           = each.value.namespace
+  period              = each.value.period
+  statistic           = each.value.statistic
+  threshold           = each.value.threshold
+  treat_missing_data  = each.value.treat_missing_data
+
+  dimensions = {
+    "MonitorName" : aws_internetmonitor_monitor.internet_monitor[0].monitor_name
+    "MeasurementSource" : "AWS"
+  }
+  actions_enabled = each.value.actions_enabled
+  alarm_actions   = [for action in each.value.alarm_actions : aws_sns_topic.sns_topics[action].arn]
+}

--- a/modules/aws-cw-internet-monitor/main.tf
+++ b/modules/aws-cw-internet-monitor/main.tf
@@ -42,6 +42,13 @@ resource "aws_internetmonitor_monitor" "internet_monitor" {
     performance_score_threshold  = var.internet_monitor_config.performance_threshold
   }
   status = var.internet_monitor_config.status
+
+  lifecycle {
+    precondition {
+      condition     = !contains([for vpc in var.internet_monitor_config.monitor_vpcs : contains(keys(var.aws_vpc), vpc)], false)
+      error_message = "Invalid VPC for Internet Monitor. Does not exist."
+    }
+  }
 }
 
 # Create SNS Topics

--- a/modules/aws-cw-internet-monitor/tests/cw_im_module.tftest.hcl
+++ b/modules/aws-cw-internet-monitor/tests/cw_im_module.tftest.hcl
@@ -1,0 +1,296 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-west-2"
+    }
+  }
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "511111111111"
+    }
+  }
+}
+
+variables {
+  project_name = "projecta"
+  environment  = "test"
+  aws_vpc = {
+    "egress" = {
+      vpc_id = "vpc-egressid"
+    }
+  }
+  internet_monitor_config = {
+    is_enabled                    = true
+    monitor_vpcs                  = ["egress"]
+    traffic_percentage_to_monitor = 50
+    max_city_networks_to_monitor  = 100
+    availability_threshold        = 96
+    performance_threshold         = 96
+    status                        = "ACTIVE"
+    alarm_config = {
+      sns_topics = {
+        "egress-alarms" = {}
+      }
+      sns_subscriptions = [
+        {
+          topic    = "egress-alarms"
+          protocol = "email"
+          endpoint = "infra-alerts@example.com"
+        }
+      ]
+      alarms = {
+        "egress-availability-score" = {
+          description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+          comparison          = "LessThanThreshold"
+          metric_name         = "AvailabilityScore"
+          namespace           = "AWS/InternetMonitor"
+          statistic           = "Average"
+          period              = 300
+          threshold           = 96
+          evaluation_periods  = 2
+          datapoints_to_alarm = 2
+          actions_enabled     = true
+          treat_missing_data  = "missing"
+          alarm_actions = [
+            "egress-alarms"
+          ]
+        }
+        "egress-performance-score" = {
+          description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+          comparison          = "LessThanThreshold"
+          metric_name         = "PerformanceScore"
+          namespace           = "AWS/InternetMonitor"
+          statistic           = "Average"
+          period              = 300
+          threshold           = 96
+          evaluation_periods  = 2
+          datapoints_to_alarm = 2
+          actions_enabled     = true
+          treat_missing_data  = "missing"
+          alarm_actions = [
+            "egress-alarms"
+          ]
+        }
+      }
+    }
+  }
+}
+
+run "positive_standard_config" {
+  command = plan
+
+  assert {
+    condition     = length(aws_internetmonitor_monitor.internet_monitor) == 1
+    error_message = "Expected 1 Internet Monitor Configured."
+  }
+
+}
+
+run "positive_standard_config_sns" {
+  command = plan
+
+  assert {
+    condition     = contains(keys(aws_sns_topic.sns_topics), "egress-alarms") && length(aws_sns_topic_subscription.sns_subscriptions) == 1
+    error_message = "Expected SNS Topic egress-alarms and 1 subscription."
+  }
+
+}
+
+run "positive_standard_config_cw" {
+  command = plan
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.internet_monitor_alarms), "egress-availability-score") && contains(keys(aws_cloudwatch_metric_alarm.internet_monitor_alarms), "egress-performance-score")
+    error_message = "Expected 2 CW Alarms."
+  }
+
+}
+
+run "positive_disabled_full_config" {
+  command = plan
+
+  variables {
+    internet_monitor_config = {
+      is_enabled                    = false
+      monitor_vpcs                  = ["egg"]
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor  = 100
+      availability_threshold        = 96
+      performance_threshold         = 96
+      status                        = "ACTIVE"
+      alarm_config = {
+        sns_topics = {
+          "egress-alarms" = {}
+        }
+        sns_subscriptions = [
+          {
+            topic    = "egress-alarms"
+            protocol = "email"
+            endpoint = "infra-alerts@example.com"
+          }
+        ]
+        alarms = {
+          "egress-availability-score" = {
+            description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "AvailabilityScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+          "egress-performance-score" = {
+            description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "PerformanceScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_internetmonitor_monitor.internet_monitor) == 0
+    error_message = "Expected 0 Internet Monitor Configured."
+  }
+
+}
+
+run "positive_disabled_no_config" {
+  command = plan
+
+  variables {
+    internet_monitor_config = {
+      is_enabled                    = false
+      monitor_vpcs                  = []
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor  = 100
+      availability_threshold        = 96
+      performance_threshold         = 96
+      status                        = "ACTIVE"
+      alarm_config = {
+        sns_topics        = {}
+        sns_subscriptions = []
+        alarms            = {}
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_internetmonitor_monitor.internet_monitor) == 0
+    error_message = "Expected 0 Internet Monitor Configured."
+  }
+
+}
+
+run "positive_enabled_no_alarms" {
+  command = plan
+
+  variables {
+    internet_monitor_config = {
+      is_enabled                    = true
+      monitor_vpcs                  = ["egress"]
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor  = 100
+      availability_threshold        = 96
+      performance_threshold         = 96
+      status                        = "ACTIVE"
+      alarm_config = {
+        sns_topics        = {}
+        sns_subscriptions = []
+        alarms            = {}
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_internetmonitor_monitor.internet_monitor) == 1 && !contains(keys(aws_sns_topic.sns_topics), "egress-alarms") && length(aws_sns_topic_subscription.sns_subscriptions) == 0
+    error_message = "Expected 1 Internet Monitor Configured."
+  }
+
+}
+
+run "negative_invalid_im_vpc" {
+  command = plan
+
+  variables {
+    internet_monitor_config = {
+      is_enabled                    = true
+      monitor_vpcs                  = ["egg"]
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor  = 100
+      availability_threshold        = 96
+      performance_threshold         = 96
+      status                        = "ACTIVE"
+      alarm_config = {
+        sns_topics = {
+          "egress-alarms" = {}
+        }
+        sns_subscriptions = [
+          {
+            topic    = "egress-alarms"
+            protocol = "email"
+            endpoint = "infra-alerts@example.com"
+          }
+        ]
+        alarms = {
+          "egress-availability-score" = {
+            description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "AvailabilityScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+          "egress-performance-score" = {
+            description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "PerformanceScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+        }
+      }
+    }
+  }
+
+  expect_failures = [
+    aws_internetmonitor_monitor.internet_monitor
+  ]
+
+}

--- a/modules/aws-cw-internet-monitor/variables.tf
+++ b/modules/aws-cw-internet-monitor/variables.tf
@@ -36,7 +36,7 @@ variable "internet_monitor_config" {
 variable "aws_vpc" {
   description = "Configured VPCs"
   type = map(object({
-    vpc_id             = string
+    vpc_id = string
   }))
 }
 

--- a/modules/aws-cw-internet-monitor/variables.tf
+++ b/modules/aws-cw-internet-monitor/variables.tf
@@ -1,0 +1,59 @@
+variable "internet_monitor_config" {
+  description = "Internet Monitor Configuration"
+  type = object({
+    is_enabled                    = bool
+    monitor_vpcs                  = list(string)
+    traffic_percentage_to_monitor = number
+    max_city_networks_to_monitor  = number
+    availability_threshold        = number
+    performance_threshold         = number
+    status                        = string
+    alarm_config = object({
+      sns_topics = map(object({}))
+      sns_subscriptions = list(object({
+        topic    = string
+        protocol = string
+        endpoint = string
+      }))
+      alarms = map(object({
+        description         = string
+        comparison          = string
+        metric_name         = string
+        namespace           = string
+        statistic           = string
+        period              = number
+        threshold           = number
+        evaluation_periods  = number
+        datapoints_to_alarm = number
+        actions_enabled     = bool
+        treat_missing_data  = string
+        alarm_actions       = list(string)
+      }))
+    })
+  })
+}
+
+variable "aws_vpc" {
+  description = "Configured VPCs"
+  type = map(object({
+    vpc_id             = string
+  }))
+}
+
+variable "project_name" {
+  description = "Project Name"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]*$", var.project_name)) && length(var.project_name) > 0
+    error_message = "Project name should be alphanumeric, can contain hyphens, and not be empty"
+  }
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]*$", var.environment)) && length(var.environment) > 0
+    error_message = "Environment should be alphanumeric, can contain hyphens, and not be empty"
+  }
+}

--- a/tests/integration.tftest.hcl
+++ b/tests/integration.tftest.hcl
@@ -229,6 +229,61 @@ variables {
         }
       ]
     }
+    internet_monitor = {
+      is_enabled                    = true
+      monitor_vpcs                  = ["egress"]
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor  = 100
+      availability_threshold        = 96
+      performance_threshold         = 96
+      status                        = "ACTIVE"
+      alarm_config = {
+        sns_topics = {
+          "egress-alarms" = {}
+        }
+        sns_subscriptions = [
+          {
+            topic    = "egress-alarms"
+            protocol = "email"
+            endpoint = "infra-alerts@example.com"
+          }
+        ]
+        alarms = {
+          "egress-availability-score" = {
+            description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "AvailabilityScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+          "egress-performance-score" = {
+            description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "PerformanceScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+        }
+      }
+    }
   }
 }
 

--- a/tests/integration_live.tftest.hcl
+++ b/tests/integration_live.tftest.hcl
@@ -220,6 +220,61 @@ variables {
         }
       ]
     }
+    internet_monitor = {
+      is_enabled                    = true
+      monitor_vpcs                  = ["egress"]
+      traffic_percentage_to_monitor = 50
+      max_city_networks_to_monitor  = 100
+      availability_threshold        = 96
+      performance_threshold         = 96
+      status                        = "ACTIVE"
+      alarm_config = {
+        sns_topics = {
+          "egress-alarms" = {}
+        }
+        sns_subscriptions = [
+          {
+            topic    = "egress-alarms"
+            protocol = "email"
+            endpoint = "infra-alerts@example.com"
+          }
+        ]
+        alarms = {
+          "egress-availability-score" = {
+            description         = "AWS Iternet Monitor Egress availability score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "AvailabilityScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+          "egress-performance-score" = {
+            description         = "AWS Iternet Monitor Egress performance score less than 96 for 5m."
+            comparison          = "LessThanThreshold"
+            metric_name         = "PerformanceScore"
+            namespace           = "AWS/InternetMonitor"
+            statistic           = "Average"
+            period              = 300
+            threshold           = 96
+            evaluation_periods  = 2
+            datapoints_to_alarm = 2
+            actions_enabled     = true
+            treat_missing_data  = "missing"
+            alarm_actions = [
+              "egress-alarms"
+            ]
+          }
+        }
+      }
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,29 @@ variable "network_config" {
         availability_threshold = number
         performance_threshold = number
         status = string
+        alarm_config = object({
+          sns_topics = map(object({}))
+          sns_subscriptions = list(object({
+            topic = string
+            protocol = string
+            endpoint = string
+          }))
+          alarms = map(object({
+            description         = string
+            comparison          = string
+            metric_name         = string
+            namespace           = string
+            statistic           = string
+            period              = number
+            threshold           = number
+            evaluation_periods  = number
+            datapoints_to_alarm = number
+            actions_enabled     = bool
+            treat_missing_data  = string
+            alarm_actions = list(string)
+          }))
+        })
       })
-  })
+    }
+  )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,17 +92,17 @@ variable "network_config" {
         }))
       })
       internet_monitor = object({
-        is_enabled   = bool
-        monitor_vpcs = list(string)
+        is_enabled                    = bool
+        monitor_vpcs                  = list(string)
         traffic_percentage_to_monitor = number
-        max_city_networks_to_monitor = number
-        availability_threshold = number
-        performance_threshold = number
-        status = string
+        max_city_networks_to_monitor  = number
+        availability_threshold        = number
+        performance_threshold         = number
+        status                        = string
         alarm_config = object({
           sns_topics = map(object({}))
           sns_subscriptions = list(object({
-            topic = string
+            topic    = string
             protocol = string
             endpoint = string
           }))
@@ -118,7 +118,7 @@ variable "network_config" {
             datapoints_to_alarm = number
             actions_enabled     = bool
             treat_missing_data  = string
-            alarm_actions = list(string)
+            alarm_actions       = list(string)
           }))
         })
       })

--- a/variables.tf
+++ b/variables.tf
@@ -91,5 +91,14 @@ variable "network_config" {
           vpc_attachment = string
         }))
       })
+      internet_monitor = object({
+        is_enabled   = bool
+        monitor_vpcs = list(string)
+        traffic_percentage_to_monitor = number
+        max_city_networks_to_monitor = number
+        availability_threshold = number
+        performance_threshold = number
+        status = string
+      })
   })
 }


### PR DESCRIPTION
Add support for Internet Monitor with SNS, Subscriptions, and CW Alarm configuration.   This adds monitoring to the egress VPCs that users configure with configurable alarms.

Closes #18 